### PR TITLE
allow custom softdebuggersessions to provide their own softdebuggeradapt...

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -95,16 +95,23 @@ namespace Mono.Debugging.Soft
 			get { return adaptor; }
 		}
 		
-		readonly SoftDebuggerAdaptor adaptor = new SoftDebuggerAdaptor ();
-		
+		readonly SoftDebuggerAdaptor adaptor;
+
 		public SoftDebuggerSession ()
 		{
+			adaptor = CreateSoftDebuggerAdaptor ();
+
 			Adaptor.BusyStateChanged += delegate(object sender, BusyStateEventArgs e) {
 				SetBusyState (e);
 			};
 			overloadResolveCache = new Dictionary<Tuple<TypeMirror,string>, MethodMirror[]> ();
 		}
-		
+
+		protected virtual SoftDebuggerAdaptor CreateSoftDebuggerAdaptor()
+		{
+			return new SoftDebuggerAdaptor();
+		}
+
 		protected override void OnRun (DebuggerStartInfo startInfo)
 		{
 			if (HasExited)


### PR DESCRIPTION
...er.  (Unity needs its own adapter, because it has a custom implementation of SoftDebuggerAdapter.IsNull)
