### PR TITLE
Removing resolving of Types because it's done sooner by new code fixing #17383

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -591,31 +591,6 @@ namespace Mono.Debugging.Evaluation
 			if (vtype != null)
 				return new TypeValueReference (ctx, vtype);
 
-			// Look in nested types
-
-			if (type != null) {
-				foreach (object ntype in ctx.Adapter.GetNestedTypes (ctx, type)) {
-					if (TypeValueReference.GetTypeName (ctx.Adapter.GetTypeName (ctx, ntype)) == name)
-						return new TypeValueReference (ctx, ntype);
-				}
-
-				string[] namespaces = ctx.Adapter.GetImportedNamespaces (ctx);
-				if (namespaces.Length > 0) {
-					// Look in namespaces
-					foreach (string ns in namespaces) {
-						string nm = ns + "." + name;
-						vtype = ctx.Adapter.ForceLoadType (ctx, nm);
-						if (vtype != null)
-							return new TypeValueReference (ctx, vtype);
-					}
-
-					foreach (string ns in namespaces) {
-						if (ns == name || ns.StartsWith (name + ".", StringComparison.InvariantCulture))
-							return new NamespaceValueReference (ctx, name);
-					}
-				}
-			}
-
 			if (self == null && ctx.Adapter.HasMember (ctx, type, name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
 				string message = string.Format ("An object reference is required for the non-static field, method, or property '{0}.{1}'.",
 				                                ctx.Adapter.GetDisplayTypeName (ctx, type), name);


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=17383

Context:
I suggest first reading #17383.
[MonoDevelop 504 pull request](https://github.com/mono/MonoDevelop/pull/504) did improve things but now I investigated fully and found cause...

First I will give sample so anyone can reproduce:
Debug on Win32 debugger.
```csharp
using System;
using System.Linq;
using System.IO;
using System.Collections.Generic;

public class Program
{
    private static int Bug17383()
    {
        int a = 0;
        a++;
        return a;
    }

    public static void Main (string[] args)
    {
        var xml = new System.Xml.ConformanceLevel ();
        var linq = new List<string> ().AsQueryable ();
        var newFile = new MemoryStream ();
        while(true)
            Bug17383 ();
    }
}
```
Put breakpoint on "Bug17383 ();" and when Breakpoint hits hover over "a" variable in Bug17383 method. It either says "Evaluating..." or you have much better PC then I do :) If thats the case add few more of random "new XXX()" from different NAMESPACES and "Evalutating..." will get longer... for example this example has 100 namespaces takes aprox 5sec MonoDevelop has 500 namespaces which takes for me aprox 1minute...

Ok now to bug...
If method [VisitIdentifierExpression](https://github.com/mono/debugger-libs/blob/master/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs#L538) can't find any variable, parameter...

It tries to find(resolve) expression as Type to do this it loop trough all namespaces that are returned by Adaptor on line 602.

With call ctx.Adapter.ForceLoadType on line 607 Adaptor loops all Types in process which takes some time multiplying this with number of namespaces... result is "Evaluating...". Pull 504 helped but only for loading private members which caused most of problems since it started loading more often but not when user hovers over variables outside current scope...

A bit more investigating... First of all since Win32 debugger does not inherit ForceLoadType so even if it finds Type it throws exception and fails to resolve type...

SoftDebugger is so fast... Why? Well because it returns only 2 namespaces empty string and "System"... This list of namespaces is generated based on resolved types during debugging and not all possible types like Win32 debugger. So it would also fail to resolve most of types...

So if both debuggers can't resolve types who does? Well this is done much sooner FullName is resolved in [StackFrame.GetExpressionValue](https://github.com/mono/debugger-libs/blob/master/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs#L246) and then into actual Type object in [NRefactoryExpressionEvaluatorVisitor.VisitMemberReferenceExpression](https://github.com/mono/debugger-libs/blob/master/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs#L788)

I hope someone with more experience and more context can review this since I'm not sure if any other software then XS is using this library and how and if that would effect those...

@mhutch @jstedfast @Therzok

Tnx for reading all this,
David