### PR TITLE
Changing back to for instead of foreach because list is modifed inside loop

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
@@ -750,7 +750,8 @@ namespace Mono.Debugging.Client
 			Dictionary<IObjectValueUpdater, List<UpdateCallback>> callbacks = null;
 			var valueList = new List<ObjectValue> (values);
 
-			foreach (var val in valueList) {
+			for (int n = 0; n < valueList.Count; n++) {
+				var val = valueList [n];
 				val.source = parentFrame.DebuggerSession.WrapDebuggerObject (val.source);
 				val.updater = parentFrame.DebuggerSession.WrapDebuggerObject (val.updater);
 				val.parentFrame = parentFrame;


### PR DESCRIPTION
This regression happened 5 days ago with https://github.com/mono/debugger-libs/commit/aef4d48f66df1146b820e5e64aaa2725e646b522 
Problem is that at line 774 list is modified which throws exception in foreach...
Added unit test into MD debugger tests will make pull soon...
