### PR TITLE
Using GetElements instead of GetElement on Array

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/ArrayElementGroup.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ArrayElementGroup.cs
@@ -154,23 +154,25 @@ namespace Mono.Debugging.Evaluation
 				int[] curIndex = new int [baseIndices.Length + 1];
 				Array.Copy (baseIndices, curIndex, baseIndices.Length);
 				string curIndexStr = IndicesToString (baseIndices);
-				if (baseIndices.Length > 0) curIndexStr += ",";
-				
-				for (int n=0; n < values.Length; n++) {
+				if (baseIndices.Length > 0)
+					curIndexStr += ",";
+				curIndex [curIndex.Length - 1] = initalIndex + firstItemIndex;
+				var elems = array.GetElements (curIndex, System.Math.Min (values.Length, upperBound + 1));
+
+				for (int n = 0; n < values.Length; n++) {
 					int index = n + initalIndex + firstItemIndex;
 					string sidx = curIndexStr + index.ToString ();
 					ObjectValue val;
-					string ename = "[" + sidx.Replace (",",", ") + "]";
+					string ename = "[" + sidx.Replace (",", ", ") + "]";
 					if (index > upperBound)
 						val = ObjectValue.CreateUnknown (sidx);
 					else {
 						curIndex [curIndex.Length - 1] = index;
-						object elem = array.GetElement (curIndex);
-						val = cctx.Adapter.CreateObjectValue (cctx, this, newPath.Append (sidx), elem, ObjectValueFlags.ArrayElement);
-						if (elem != null && !cctx.Adapter.IsNull (cctx, elem)) {
-							TypeDisplayData tdata = cctx.Adapter.GetTypeDisplayData (cctx, cctx.Adapter.GetValueType (cctx, elem));
+						val = cctx.Adapter.CreateObjectValue (cctx, this, newPath.Append (sidx), elems.GetValue (n), ObjectValueFlags.ArrayElement);
+						if (elems.GetValue (n) != null && !cctx.Adapter.IsNull (cctx, elems.GetValue (n))) {
+							TypeDisplayData tdata = cctx.Adapter.GetTypeDisplayData (cctx, cctx.Adapter.GetValueType (cctx, elems.GetValue (n)));
 							if (!string.IsNullOrEmpty (tdata.NameDisplayString))
-								ename = cctx.Adapter.EvaluateDisplayString (cctx, elem, tdata.NameDisplayString);
+								ename = cctx.Adapter.EvaluateDisplayString (cctx, elems.GetValue (n), tdata.NameDisplayString);
 						}
 					}
 					val.Name = ename;


### PR DESCRIPTION
Before this change elements were fetched one by one resulting in many unnecessary round trips to runtime.   Before merging this pull request. Pull request 556 on MD must be accepted: https://github.com/mono/monodevelop/pull/556

This is partly fixing: https://bugzilla.xamarin.com/show_bug.cgi?id=19877 this is reducing from 300 round trips to 201 finding way to go down to 3 round trips...

In case of integers(primitives) arrays this is reducing roundtrips from 100 to 1...
