### PR TITLE
Bug 19927 - [Regression] Cannot debug framework code

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -449,7 +449,7 @@ namespace Mono.Debugging.Soft
 		
 		void RegisterUserAssemblies (SoftDebuggerStartInfo dsi)
 		{
-			if (dsi.UserAssemblyNames != null) {
+			if (Options.ProjectAssembliesOnly && dsi.UserAssemblyNames != null) {
 				assemblyFilters = new List<AssemblyMirror> ();
 				userAssemblyNames = dsi.UserAssemblyNames.Select (x => x.ToString ()).ToList ();
 			}


### PR DESCRIPTION
@jstedfast Do you know reason why this this check was removed in https://github.com/mono/debugger-libs/commit/0928314bbacbb896e36297e52ba4a8f532826e5b#diff-b06f2117f17d0875b3d984f24e1e03a5L445 ?
