### PR TITLE
FetchFrames implementation + removed MirrorThread cache(cached in Mono.Debugger.Soft now)

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -1577,6 +1577,20 @@ namespace Mono.Debugging.Client
 				return frontend;
 			}
 		}
+
+		protected virtual void OnFetchFrames (ThreadInfo[] threads)
+		{
+		}
+
+		/// <summary>
+		/// Calling this method is optional.
+		/// It's usefull to call this method so underlying debugger can optimize speed of fetching multiple frames on <paramref name="threads"/>.
+		/// </summary>
+		/// <param name="threads">Array of threads to fetch frames.</param>
+		public void FetchFrames (ThreadInfo[] threads)
+		{
+			OnFetchFrames (threads);
+		}
 	}
 	
 	class InternalDebuggerSession: IDebuggerSessionFrontend


### PR DESCRIPTION
Added virtual method FetchFrames in DebuggerSession to be able to request Frames in bulk and also implemented in SoftDebuggerSession

Removed mirrorThreads caching in SoftDebuggerSession since it's now done inside VirtualMacine
