### PR TITLE
[Mono.Debugging] If value was null builtin types were not normalized e.g System.Byte to byte

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
@@ -143,7 +143,7 @@ namespace Mono.Debugging.Evaluation
 			if (val != null)
 				return newCtx.Adapter.CreateObjectValue (newCtx, this, new ObjectPath (name), val, Flags);
 
-			return Mono.Debugging.Client.ObjectValue.CreateNullObject (this, name, newCtx.Adapter.GetTypeName (newCtx, Type), Flags);
+			return Mono.Debugging.Client.ObjectValue.CreateNullObject (this, name, newCtx.Adapter.GetDisplayTypeName (newCtx.Adapter.GetTypeName (newCtx, Type)), Flags);
 		}
 
 		ObjectValue IObjectValueSource.GetValue (ObjectPath path, EvaluationOptions options)


### PR DESCRIPTION
Just added additional call to newCtx.Adapter.GetDisplayTypeName which takes care of converting System.Byte to byte and other built-in types...
