### PR TITLE
[Mono.Debugger.Soft] Fix bug 22194 - cannot use typeof with type paramet...

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -1246,6 +1246,39 @@ namespace Mono.Debugging.Soft
 					return tm;
 			}
 
+			if (cx.Frame.Method.IsGenericMethod) {
+				var method = cx.Frame.Method;
+
+				if (!method.IsGenericMethodDefinition) {
+					TypeMirror[] names, instantiatedTypes;
+
+					instantiatedTypes = method.GetGenericArguments ();
+					method = method.GetGenericMethodDefinition ();
+					names = method.GetGenericArguments ();
+
+					for (i = 0; i < names.Length; i++) {
+						if (names [i].FullName == name)
+							return instantiatedTypes [i];
+					}
+				}
+			}
+
+			if (cx.Frame.Method.DeclaringType.IsGenericType) {
+				var declaringType = cx.Frame.Method.DeclaringType;
+				if (!declaringType.IsGenericTypeDefinition) {
+					TypeMirror[] names, instantiatedTypes;
+
+					instantiatedTypes = declaringType.GetGenericArguments ();
+					declaringType = declaringType.GetGenericTypeDefinition ();
+					names = declaringType.GetGenericArguments ();
+
+					for (i = 0; i < names.Length; i++) {
+						if (names [i].FullName == name)
+							return instantiatedTypes [i];
+					}
+				}
+			}
+
 			return null;
 		}
 


### PR DESCRIPTION
...ers.

If the current method is generic or the declaring type of the method is generic look to see if the name matches one of the type arguments.
