### PR TITLE
For Windows use GetFullPath instead of throwing

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2317,6 +2317,9 @@ namespace Mono.Debugging.Soft
 
 		static string ResolveSymbolicLink (string path)
 		{
+			if (IsWindows)
+				return Path.GetFullPath (path);
+
 			if (path.Length == 0)
 				return path;
 


### PR DESCRIPTION
On Windows, ResolveSymbolicLink tries to create a Mono.Unix.UnixSymbolicLinkInfo and throws exception and then returns the possibly short path. 
Really annoying when debugging, not to mention two equal paths might not then be compared equal.

ResolveFullPath used to be called instead of ResolveSymbolicLink which for Windows just used GetFullPath so go back to the old behaviour if IsWindows
