### PR TITLE
Use GetFullPath on Windows instead of throwing exception

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2320,6 +2320,9 @@ namespace Mono.Debugging.Soft
 			if (path.Length == 0)
 				return path;
 
+			if (IsWindows)
+				return Path.GetFullPath (path);
+
 			try {
 				var alreadyVisted = new HashSet<string> ();
 


### PR DESCRIPTION
On Windows an exception would be thrown because of attempt to use Unix only feature, Mono.Unix.UnixSymbolicLinkInfo. Really annoying in debugger and might not then compare to equals paths as equal because short path can be returned.

Closest thing to resolving symbolic path on Windows is to get full path. Old behaviour did this so do that if IsWindows.

(Re-requesting pull because of error with previous commit)
