### PR TITLE
Added precomputed breakpoint for IDEs that can auto-resolve ILOffset

### DIFF
--- a/Mono.Debugging.Soft/InstructionBreakpoint.cs
+++ b/Mono.Debugging.Soft/InstructionBreakpoint.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Mono.Debugging.Client;
+
+namespace Mono.Debugging.Soft
+{
+	[Serializable]
+	public class InstructionBreakpoint : Breakpoint
+	{
+		public string MethodName { get; set; }
+		public long ILOffset { get; private set; }
+
+		public InstructionBreakpoint (string fileName, int line, int column, long ilOffset) : base (fileName, line, column)
+		{
+			this.ILOffset = ilOffset;
+		}
+
+	}
+}

--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="ArrayAdaptor.cs" />
     <Compile Include="FieldValueReference.cs" />
+    <Compile Include="InstructionBreakpoint.cs" />
     <Compile Include="PropertyValueReference.cs" />
     <Compile Include="SoftDebuggerSession.cs" />
     <Compile Include="VariableValueReference.cs" />

--- a/Mono.Debugging/Mono.Debugging.Client/Breakpoint.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Breakpoint.cs
@@ -154,7 +154,7 @@ namespace Mono.Debugging.Client
 		internal bool HasAdjustedLine {
 			get { return adjustedLine != -1; }
 		}
-		
+
 		public override void CopyFrom (BreakEvent ev)
 		{
 			base.CopyFrom (ev);

--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -125,9 +125,7 @@
     <Compile Include="Mono.Debugging.Client\RunToCursorBreakpoint.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Folder Include="Mono.Debugging.Evaluation\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\..\nrefactory\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">
       <Project>{3B2A5653-EC97-4001-BB9B-D90F1AF2C371}</Project>


### PR DESCRIPTION
Added a new PrecomputedBreakpoint class, inheriting from Breakpoint. The only difference is that Precompute includes method name and ILOffset, which I can find before calling the debugger. This allows me to set breakpoints in delegate code, in the same line, without having to guess location by line/column. I also added a corresponding FindLocationByILOffset, matching the signature of FindLocationByType as much as I could. This change is purely incremental and backwards compatible. If Precomputed is not used, nothing is changed at all.

/cc @jstedfast @migueldeicaza 
