### PR TITLE
[Soft] Changed IsClosureReferenceField from "<>f__ref" to "$locvar"

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -600,10 +600,12 @@ namespace Mono.Debugging.Soft
 		
 		static bool IsClosureReferenceField (FieldInfoMirror field)
 		{
-			// mcs is "<>f__ref"
+			// mcs is "$locvar"
 			// csc is "CS$<>"
+			// roslyn is "<>8__"
 			return field.Name.StartsWith ("CS$<>", StringComparison.Ordinal) ||
-				field.Name.StartsWith ("<>f__ref", StringComparison.Ordinal);
+			field.Name.StartsWith ("$locvar", StringComparison.Ordinal) ||
+			field.Name.StartsWith ("<>8__", StringComparison.Ordinal);
 		}
 		
 		static bool IsClosureReferenceLocal (LocalVariable local)


### PR DESCRIPTION
This fixes [Bug 24998](https://bugzilla.xamarin.com/show_bug.cgi?id=24998).
I also ran unit tests and added unit tests for this bug and I can't detect any regression. But I don't feel 100% about this change.

"<>8__" is added because this is used in Roslyn.