### PR TITLE
Provide exit code for TargetExited event when available.

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/TargetEventArgs.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/TargetEventArgs.cs
@@ -53,5 +53,9 @@ namespace Mono.Debugging.Client
 		public BreakEvent BreakEvent {
 			get; set;
 		}
+
+		public int? ExitCode {
+			get; set;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #10.