### PR TITLE
Remove break event request from breakpoints dictionary when removing a breakpoint

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1042,8 +1042,10 @@ namespace Mono.Debugging.Soft
 
 			var bi = (BreakInfo) eventInfo;
 			if (bi.Requests.Count != 0) {
-				foreach (var request in bi.Requests)
+				foreach (var request in bi.Requests) {
 					request.Enabled = false;
+					breakpoints.Remove (request);
+				}
 
 				RemoveQueuedBreakEvents (bi.Requests);
 			}


### PR DESCRIPTION
Fixes issue with removed breakpoint being added again in HandleAssemblyUnloadEvents.

When adding and removing a breakpoint while the soft debugger is attached, the breakpoint is not removed from the breakpoints dictionary. HandleAssemblyUnloadEvents will add any (removed) breakpoint from the breakpoints dictionary to pending_bes, causing the (removed) breakpoint to be added again.

This issue can be produced as follows:

- Attach soft debugger
- Add and remove a breakpoint.
- Reload the assembly in which the breakpoint was set.
- Run
- Debugger breaks on the removed breakpoint.