### PR TITLE
Domain unload workaround

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -417,7 +417,7 @@ namespace Mono.Debugging.Soft
 			
 			HideConnectionDialog ();
 			
-			machine.EnableEvents (EventType.AssemblyLoad, EventType.ThreadStart, EventType.ThreadDeath,
+			machine.EnableEvents (EventType.AppDomainCreate, EventType.AppDomainUnload, EventType.AssemblyLoad, EventType.ThreadStart, EventType.ThreadDeath,
 				EventType.AssemblyUnload, EventType.UserBreak, EventType.UserLog);
 			try {
 				unhandledExceptionRequest = machine.CreateExceptionRequest (null, false, true);


### PR DESCRIPTION
Workound for SoftDebuggerSession.GetType returning an unloaded type due to issue: https://github.com/mono/debugger-libs/issues/57