### PR TITLE
Clear breakpoint requests on assembly unload

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1863,6 +1863,8 @@ namespace Mono.Debugging.Soft
 				int line = breakpoint.Value.Location.LineNumber;
 				OnDebuggerOutput (false, string.Format ("Re-pending breakpoint at {0}:{1}\n", file, line));
 				breakpoints.Remove (breakpoint.Key);
+				breakpoint.Value.Requests.Clear ();
+
 				lock (pending_bes) {
 					pending_bes.Add (breakpoint.Value);
 				}


### PR DESCRIPTION
The BreakpointEventRequests have a MethodMirror member and the method it represents is also unloaded when unloading the assembly and therefore no longer valid.

The BreakpointEventRequests are not used when resolving pending_bes in ResolveBreakpoints and a new request is added in InsertBreakpoint, so the breakpoint is correctly re-added when the assembly/type is loaded again.

Fixes ERR_UNLOADED errors when enabling/disabling breakpoints after a assembly unload.