### PR TITLE
Bug 33614 - [Roslyn] Crash in debugger after pausing

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -720,11 +720,15 @@ namespace Mono.Debugging.Soft
 			return name;
 		}
 
-		protected override void OnFetchFrames (ThreadInfo[] threads)
+		protected override void OnFetchFrames (ThreadInfo [] threads)
 		{
-			var mirrorThreads = new ThreadMirror[threads.Length];
-			for (int i = 0; i < threads.Length; i++)
-				mirrorThreads [i] = GetThread (threads [i].Id);
+			var mirrorThreads = new List<ThreadMirror> (threads.Length);
+			for (int i = 0; i < threads.Length; i++) {
+				var thread = GetThread (threads [i].Id);
+				if (thread != null) {
+					mirrorThreads.Add (thread);
+				}
+			}
 			ThreadMirror.FetchFrames (mirrorThreads);
 		}
 
@@ -1912,6 +1916,7 @@ namespace Mono.Debugging.Soft
 
 		void HandleThreadStartEvents (ThreadStartEvent[] events)
 		{
+			current_threads = null;
 			var thread = events [0].Thread;
 			if (events.Length > 1 && events.Any (a => a.Thread != thread))
 				throw new InvalidOperationException ("Simultaneous ThreadStartEvents for multiple threads");
@@ -1926,6 +1931,7 @@ namespace Mono.Debugging.Soft
 
 		void HandleThreadDeathEvents (ThreadDeathEvent[] events)
 		{
+			current_threads = null;
 			var thread = events [0].Thread;
 			if (events.Length > 1 && events.Any (a => a.Thread != thread))
 				throw new InvalidOperationException ("Simultaneous ThreadDeathEvents for multiple threads");

--- a/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
@@ -36,18 +36,11 @@ namespace Mono.Debugging.Client
 		string name;
 		
 		[NonSerialized]
-		ThreadInfo[] currentThreads;
-		
-		[NonSerialized]
 		DebuggerSession session;
 		
 		internal void Attach (DebuggerSession session)
 		{
 			this.session = session;
-			if (currentThreads != null) {
-				foreach (ThreadInfo t in currentThreads)
-					t.Attach (session);
-			}
 		}
 		
 		public long Id {
@@ -70,9 +63,7 @@ namespace Mono.Debugging.Client
 		
 		public ThreadInfo[] GetThreads ()
 		{
-			if (currentThreads == null)
-				currentThreads = session.GetThreads (id);
-			return currentThreads;
+			return session.GetThreads (id);
 		}
 	}
 }


### PR DESCRIPTION
Problem was outdated threads list in ProcessInfo... And when this threads were mapped to ThreadMirrors outdated thread(which was now dead) was converted into null which caused NRE...
1. OnFetchFrames now handles this possibility and excludes null references from list
2. ProcessInfo is no longer caching threads instead they are requested from DebuggerSession which should do caching as it already does...
3. current_threads cache in SoftDebuggerSession wasn't invalidated on threads start/stop events as it should be...