### PR TITLE
[Debugger] Set the encoding of the error/output readers.

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.Remoting.Messaging;
+using System.Text;
 
 namespace Mono.Debugger.Soft
 {
@@ -94,6 +95,9 @@ namespace Mono.Debugger.Soft
 			if (options != null && options.Valgrind)
 				info.FileName = "valgrind";
 			info.UseShellExecute = false;
+
+			info.StandardErrorEncoding = Encoding.UTF8;
+			info.StandardOutputEncoding = Encoding.UTF8;
 
 			ITargetProcess p;
 			if (options != null && options.CustomProcessLauncher != null)


### PR DESCRIPTION
Bug 40556 - Output pad no longer displays unicode characters