### PR TITLE
Surfacing IncludeSubclasses for Catchpoints

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -143,13 +143,18 @@ namespace Mono.Debugging.Client
 		
 		public Catchpoint AddCatchpoint (string exceptionName)
 		{
+			return AddCatchpoint (exceptionName, true);
+		}
+
+		public Catchpoint AddCatchpoint (string exceptionName, bool includeSubclasses)
+		{
 			if (exceptionName == null)
 				throw new ArgumentNullException ("exceptionName");
 
 			if (IsReadOnly)
 				return null;
 
-			var cp = new Catchpoint (exceptionName);
+			var cp = new Catchpoint (exceptionName, includeSubclasses);
 			Add (cp);
 
 			return cp;


### PR DESCRIPTION
Exceptions in VS are not hierarchical, so we need to surface this property to be able to _not_ include subclasses when requesting a catchpoint.