### PR TITLE
[Session] Fix every source file having a copy of every method instance.

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2606,16 +2606,19 @@ namespace Mono.Debugging.Soft
 
 			using(MonoSymbolFile mdb = MonoSymbolFile.ReadSymbolFile(mdbFileName))
 			{
-				foreach (var src in mdb.Sources) 
+				foreach (var cu in mdb.CompileUnits)
 				{
 					MdbSourceFileInfo info = new MdbSourceFileInfo ();
 
+					var src = cu.SourceFile;
 					info.Hash = src.Checksum;
 					info.FileID = src.Index;
 					info.FullFilePath = src.FileName;
 
-					foreach (var method in mdb.Methods) 
-						info.Methods.Add (new MethodMdbInfo{ SequencePoints = method.GetLineNumberTable ().LineNumbers });
+					foreach (var method in mdb.Methods) {
+						if (method.CompileUnitIndex == cu.Index)
+							info.Methods.Add (new MethodMdbInfo { SequencePoints = method.GetLineNumberTable ().LineNumbers });
+					}
 
 					fileToSourceFileInfos [src.FileName] = new List<MdbSourceFileInfo> ();
 


### PR DESCRIPTION
This decreases memory usage by having only methods in a source file being used inside.

Based on my analysis of mdb writers, the mapping is one CompilationUnit
for each SourceFileEntry.

See MdbWriter and SymbolWriterImpl and grep for DefineDocument.

Bug 45792 - Exponential memory usage when loading mdb files