### PR TITLE
Fixed breakpoint resolve on old Mono runtime

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2796,6 +2796,10 @@ namespace Mono.Debugging.Soft
 						return true;
 					if (entry.Row == line && column >= entry.Column && entry.Column > found.ColumnNumber)
 						return true;
+					if (vm.Version.AtLeast (2, 19)) { //if version is less then 2.19, found Location will not contain info about columns
+						if (entry.Row == line && column >= entry.Column && entry.Column > found.ColumnNumber)
+							return true;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixed breakpoint resolve on old Mono runtime if bp has non zero column (< 2.19) (e.g. Unity 5.5)
Breakpoint resolving failed on Unity 5.5. Old runtime had no info about column but if the code was compiled with fresh compiler so the mdb has info about colums. In this case in IDE try to set breakpoint exactly before Debug.Log("1") on line 12, column 3 (not column 0) it can't be resolved

```
using UnityEngine;

public class Test : MonoBehaviour
{
   // Use this for initialization
   void Start()
   {
   }

   // Update is called once per frameÍ
   void Update()
   {
       |breakpoint_here|Debug.Log("1");
   }
}
```