### PR TITLE
Mute exception on step phase in the case of old version of protocol.

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1442,7 +1442,13 @@ namespace Mono.Debugging.Soft
 						req.Filter |= StepFilter.DebuggerNonUserCode;
 					if (assemblyFilters != null && assemblyFilters.Count > 0)
 						req.AssemblyFilter = assemblyFilters;
-					req.Enabled = true;
+					try {
+						req.Enabled = true;
+					}
+					catch (NotSupportedException e) {
+						if (vm.Version.AtLeast (2, 19)) //catch NotSupportedException thrown by old version of protocol
+							throw e;
+					}
 					currentStepRequest = req;
 					OnResumed ();
 					vm.Resume ();


### PR DESCRIPTION
Exception occured on Unity 5.5 (that uses old Mono)