### PR TITLE
invalidate stacks on setNextStatement

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -880,6 +880,8 @@ namespace Mono.Debugging.Soft
 
 			try {
 				thread.SetIP (location);
+				StackVersion++;
+				RaiseStopEvent ();
 			} catch (ArgumentException) {
 				throw new NotSupportedException ();
 			}

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -960,7 +960,13 @@ namespace Mono.Debugging.Client
 			return result.Evaluator;
 		}
 		
-		
+		protected void RaiseStopEvent ()
+		{
+			EventHandler<TargetEventArgs> targetEvent = TargetEvent;
+			if (targetEvent != null)
+				targetEvent (this, new TargetEventArgs (TargetEventType.TargetStopped));
+		}
+
 		/// <summary>
 		/// Called when an expression needs to be resolved
 		/// </summary>


### PR DESCRIPTION
Invalidate stacks version on setNextStatement Action, so you have actual info about stacks.
Also notify listeners about stop with new thread state by raising stop event.
Was:
![sns1](https://cloud.githubusercontent.com/assets/5597729/21925831/3eaae87c-d990-11e6-910e-5b01f44767e4.gif)
Now:
![sns2](https://cloud.githubusercontent.com/assets/5597729/21925838/45109392-d990-11e6-8500-3b76a15e980c.gif)
If you approve this, will send pull request for CorDebuggerSession
