### PR TITLE
Handling exceptions in OnRun() before ForceExit

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -328,8 +328,10 @@ namespace Mono.Debugging.Client
 					try {
 						OnRun (startInfo);
 					} catch (Exception ex) {
+						// should handle exception before raising Exit event because HandleException may ignore exceptions in Exited state
+						var exceptionHandled = HandleException (ex);
 						ForceExit ();
-						if (!HandleException (ex))
+						if (!exceptionHandled)
 							throw;
 					}
 				});

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -365,8 +365,10 @@ namespace Mono.Debugging.Client
 						OnAttachToProcess (proc.Id);
 						attached = true;
 					} catch (Exception ex) {
+						// should handle exception before raising Exit event because HandleException may ignore exceptions in Exited state
+						var exceptionHandled = HandleException (ex);
 						ForceExit ();
-						if (!HandleException (ex))
+						if (!exceptionHandled)
 							throw;
 					}
 				});
@@ -511,8 +513,10 @@ namespace Mono.Debugging.Client
 					try {
 						OnFinish ();
 					} catch (Exception ex) {
+						// should handle exception before raising Exit event because HandleException may ignore exceptions in Exited state
+						var exceptionHandled = HandleException (ex);
 						ForceExit ();
-						if (!HandleException (ex))
+						if (!exceptionHandled)
 							throw;
 					}
 				});


### PR DESCRIPTION
Handling exceptions in OnRun() before ForceExit, because otherwise the session is ended and the exception may be ignored.