### PR TITLE
Bug 44851 - [Xamarin Studio] Expression Evaluator Does Not Mirror C# Console Expected Results

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -106,6 +106,10 @@ namespace Mono.Debugging.Evaluation
 
 		static Type GetCommonType (object v1, object v2)
 		{
+			if (v1 is double || v2 is double)
+				return typeof (double);
+			if (v1 is float || v2 is float)
+				return typeof (float);
 			int s1 = Marshal.SizeOf (v1);
 			if (IsUnsigned (s1))
 				s1 += 8;


### PR DESCRIPTION
Problem was that result type was `int` instead of `float`