### PR TITLE
Use NUnit from NuGet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin
 obj
+packages
 *~
 *.sln.cache
 *.suo

--- a/UnitTests/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests/UnitTests.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
-      <Private>False</Private>
+      <HintPath>..\..\packages\NUnit.3.6.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -59,5 +59,8 @@
       <Project>{372E8E3E-29D5-4B4D-88A2-4711CD628C4E}</Project>
       <Name>Mono.Debugger.Soft</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/UnitTests/UnitTests/packages.config
+++ b/UnitTests/UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.1" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
System NUnit is deprecated in Mono now.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52774