### PR TITLE
Fixed bug with breakpoints not working after assembly reload

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1017,7 +1017,12 @@ namespace Mono.Debugging.Soft
 					bi.SetStatus (BreakEventStatus.NotBound, null);
 				}
 			}
+			UpdateTypeLoadFilters ();
+			return bi;
+		}
 
+		void UpdateTypeLoadFilters()
+		{
 			/*
 			 * TypeLoad events lead to too much wire traffic + suspend/resume work, so
 			 * filter them using the file names used by pending breakpoints.
@@ -1065,8 +1070,6 @@ namespace Mono.Debugging.Soft
 					typeLoadTypeNameReq.Enabled = true;
 				}
 			}
-
-			return bi;
 		}
 
 		private Location FindLocationByILOffset (InstructionBreakpoint bp, string filename, out bool isGeneric, out bool insideTypeRange)
@@ -1945,9 +1948,11 @@ namespace Mono.Debugging.Soft
 				breakpoints.Remove (breakpoint.Key);
 				breakpoint.Value.Requests.Clear ();
 
+				breakpoint.Value.SetStatus (BreakEventStatus.NotBound, "Assembly unloaded");
 				lock (pending_bes) {
 					pending_bes.Add (breakpoint.Value);
 				}
+				UpdateTypeLoadFilters ();
 			}
 
 			// Remove affected types from the loaded types list

--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -1187,6 +1187,19 @@ namespace Mono.Debugging.Tests
 					break;
 			}
 		}
+
+		[Test]
+		public void BugDomainBreakpointNotBound ()
+		{
+			InitializeTest ();
+			Session.Options.ProjectAssembliesOnly = false;
+			var file = ReadFile (Path.Combine (Path.GetDirectoryName (TargetProjectSourceDir), "MonoDevelop.Debugger.Tests.AppDomainClient", "Client.cs"));
+			AddBreakpoint ("3fda6c6b-9c2f-412b-9d0b-012bacdce577");
+			StartTest ("TestBugDomainBreakpointNotBound");
+			CheckPosition ("3fda6c6b-9c2f-412b-9d0b-012bacdce577");
+			AddBreakpoint ("c6632437-1cac-45db-ac15-0ca13cf02aa1", file: file);
+			Continue ("c6632437-1cac-45db-ac15-0ca13cf02aa1", file: file);
+		}
 	}
 }
 

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/BreakpointsAndStepping.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/BreakpointsAndStepping.cs
@@ -469,6 +469,16 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			AppDomain.Unload (domain1);/*e0aa9771-8072-4ae5-b827-51f44b281f4d*/
 		}
 
+		public void TestBugDomainBreakpointNotBound()
+		{
+			var domain1 = AppDomain.CreateDomain ("domain1", null, new AppDomainSetup () { ApplicationBase = "." });
+			domain1.ExecuteAssembly ("MonoDevelop.Debugger.Tests.AppDomainClient.exe", new [] { "1", "2", "3" });
+			AppDomain.Unload (domain1);/*3fda6c6b-9c2f-412b-9d0b-012bacdce577*/
+			var domain2 = AppDomain.CreateDomain ("domain2", null, new AppDomainSetup () { ApplicationBase = "." });
+			domain2.ExecuteAssembly ("MonoDevelop.Debugger.Tests.AppDomainClient.exe", new [] { "1", "2", "3" });
+			AppDomain.Unload (domain2);
+		}
+
 		class DontUseThisClassInOtherTests
 		{
 			//Or StaticConstructorStepping will fail because


### PR DESCRIPTION
This happened only if assembly was already loaded when breakpoint was enabled(common in Unity projects since editor has assemblies loaded), this was problem if TypeLoadRequest was not set 1st time when breakpoint was added because type was already loaded, in that case when breakpoint was unbounded and assembly was loaded again IDE was not notified about type being loaded, hence breakpoint was not placed, this is now fixed by calling UpdateTypeLoadFIlters(); after breakpoint is re-added to pending_bes