### PR TITLE
Bug 56964 - 2 unit tests for debugger(breakpoint+domain) are disabled

### DIFF
--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -1153,7 +1153,6 @@ namespace Mono.Debugging.Tests
 		}
 
 		[Test]
-		[Ignore]
 		public void Bug53371()
 		{
 			InitializeTest();
@@ -1190,7 +1189,6 @@ namespace Mono.Debugging.Tests
 		}
 
 		[Test]
-		[Ignore]
 		public void BugDomainBreakpointNotBound ()
 		{
 			InitializeTest ();


### PR DESCRIPTION
While running unit tests I noticed that actionsQueue in DebuggerSession.cs is throwing exceptions that Dequeue is attempted on empty queue… Turns out that if 2nd Dispatch is called while 1st one is executing… It’s likely that 3rd lock() will deque, 1st lock() will take lock before 2nd which results in 2nd thread starting and 2 threads executing same action and Dequeing(hence exception)

Actual bugfix is in SoftDebuggerSession.cs 3 problems needed to be fixed:
1) Call `breakpoint.Value.Requests.Clear ();` removed requests for all domains instead just unloaded one…
2) not adding to `pending_breakpoints` when breakpoint was resolved was wrong, because if 2nd domain loads… it didn’t place breakpoint
3) We now track all assemblies we work with and keep them in list with domain so when domain unloads we unload assemblies(workaround 51294)