### PR TITLE
Break ResolveSymbolicLink into Windows and non-Windows methods

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2588,9 +2588,19 @@ namespace Mono.Debugging.Soft
 				return path;
 
 			if (IsWindows)
-				return Path.GetFullPath (path);
+				return ResolveWindowsSymbolicLink (path);
 
-			try {
+            return ResolveUnixSymbolicLink (path);
+		}
+
+        static string ResolveWindowsSymbolicLink (string path)
+        {
+            return Path.GetFullPath (path);
+        }
+
+        static string ResolveUnixSymbolicLink (string path)
+        {
+   			try {
 				var alreadyVisted = new HashSet<string> ();
 
 				while (true) {
@@ -2619,7 +2629,7 @@ namespace Mono.Debugging.Soft
 			} catch {
 				return path;
 			}
-		}
+        }
 		
 		static bool PathsAreEqual (string p1, string p2)
 		{


### PR DESCRIPTION
In Windows it's better not to have Mono.Posix ever loaded in the process. The previous method forced the load by referencing it in code. With this separation, Posix will never load unless ResolveSymbolicLinkUnix is actually called.