### PR TITLE
Bug 57051 - Crash when starting debugger

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1929,7 +1929,7 @@ namespace Mono.Debugging.Soft
 
 		void HandleAssemblyUnloadEvents (AssemblyMirror asm)
 		{
-			assemblyFilters.Remove (asm);
+			assemblyFilters?.Remove (asm);
 
 			// Mark affected breakpoints as pending again
 			var affectedBreakpoints = new List<KeyValuePair<EventRequest, BreakInfo>> (breakpoints.Where (x => x.Value.Requests.TryGetValue (x.Key, out var a) && a == asm));


### PR DESCRIPTION
This null check was removed in ebd0069bcc when I cleaned code a bit(removed needless index based removing) and accidentally also removed null check

https://github.com/mono/debugger-libs/commit/ebd0069bcc#diff-b06f2117f17d0875b3d984f24e1e03a5L1938