### PR TITLE
Merging master into 15.3

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -119,9 +119,6 @@ namespace Mono.Debugger.Soft
 		public int[] live_range_end;
 		public int[] scopes_start;
 		public int[] scopes_end;
-		public int nhoisted;
-		public int[] hoisted_scopes_start;
-		public int[] hoisted_scopes_end;
 	}
 
 	struct PropInfo {
@@ -424,7 +421,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 46;
+		internal const int MINOR_VERSION = 45;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -1917,15 +1914,6 @@ namespace Mono.Debugger.Soft
 					info.scopes_start [i] = last_start + res.ReadInt ();
 					info.scopes_end [i] = info.scopes_start [i] + res.ReadInt ();
 					last_start = info.scopes_start [i];
-				}
-				if (Version.AtLeast (2, 46)) {
-					info.nhoisted = res.ReadInt ();
-					info.hoisted_scopes_start = new int [info.nhoisted];
-					info.hoisted_scopes_end = new int [info.nhoisted];
-					for (int i = 0; i < info.nhoisted; ++i) {
-						info.hoisted_scopes_start [i] = res.ReadInt ();
-						info.hoisted_scopes_end [i] = res.ReadInt ();
-					}
 				}
 			}
 

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -24,7 +24,6 @@ namespace Mono.Debugger.Soft
 		MethodBodyMirror body;
 		MethodMirror gmd;
 		TypeMirror[] type_args;
-		LocalScope[] hoisted_scopes;
 
 		internal MethodMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -242,19 +241,10 @@ namespace Mono.Debugger.Soft
 		}
 
 		public LocalScope [] GetScopes () {
-			vm.CheckProtocolVersion (2, 43);
+			if (!vm.Version.AtLeast (2, 43))
+				throw new InvalidOperationException ("Scopes support was implemented in 2.43 version of protocol.");
 			GetLocals ();
 			return scopes;
-		}
-
-		//
-		// Return the contents of the State Machine Hoisted Locals Scope record:
-		// https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#state-machine-hoisted-local-scopes-c--vb-compilers
-		//
-		public LocalScope [] GetHoistedScopes () {
-			vm.CheckProtocolVersion (2, 46);
-			GetLocals ();
-			return hoisted_scopes;
 		}
 
 		public LocalVariable[] GetLocals () {
@@ -282,10 +272,6 @@ namespace Mono.Debugger.Soft
 					for (int i = 0; i < scopes.Length; ++i)
 						scopes [i] = new LocalScope (vm, this, li.scopes_start [i], li.scopes_end [i]);
 				}
-
-				hoisted_scopes = new LocalScope [li.nhoisted];
-				for (int i = 0; i < li.nhoisted; ++i)
-					hoisted_scopes [i] = new LocalScope (vm, this, li.hoisted_scopes_start [i], li.hoisted_scopes_end [i]);
 			}
 			return locals;
 		}

--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -63,6 +63,7 @@
     <Compile Include="LocalVariableBatch.cs" />
     <Compile Include="ThisValueReference.cs" />
     <Compile Include="FieldReferenceBatch.cs" />
+    <Compile Include="PortablePdbData.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -79,6 +80,14 @@
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
       <HintPath>$(SolutionDir)\packages\Mono.Cecil.0.10.0-beta5\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(SolutionDir)\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>$(SolutionDir)\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <Import Project="..\Mono.Debugging.settings" />

--- a/Mono.Debugging.Soft/PortablePdbData.cs
+++ b/Mono.Debugging.Soft/PortablePdbData.cs
@@ -1,0 +1,104 @@
+﻿//
+// PortablePdbData.cs
+//
+// Author:
+//       David Karlaš <david.karlas@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Reflection.Metadata;
+using Mono.Debugger.Soft;
+using System.IO;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+
+namespace Mono.Debugging.Soft
+{
+	class PortablePdbData
+	{
+		public static readonly Guid AsyncMethodSteppingInformationBlob = new Guid ("54FD2AC5-E925-401A-9C2A-F94F171072F8");
+		public static readonly Guid StateMachineHoistedLocalScopes = new Guid ("6DA9A61E-F8C7-4874-BE62-68BC5630DF71");
+		public static readonly Guid DynamicLocalVariables = new Guid ("83C563C4-B4F3-47D5-B824-BA5441477EA8");
+		public static readonly Guid TupleElementNames = new Guid ("ED9FDF71-8879-4747-8ED3-FE5EDE3CE710");
+		public static readonly Guid DefaultNamespace = new Guid ("58b2eab6-209f-4e4e-a22c-b2d0f910c782");
+		public static readonly Guid EncLocalSlotMap = new Guid ("755F52A8-91C5-45BE-B4B8-209571E552BD");
+		public static readonly Guid EncLambdaAndClosureMap = new Guid ("A643004C-0240-496F-A783-30D64F4979DE");
+		public static readonly Guid SourceLink = new Guid ("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+		public static readonly Guid EmbeddedSource = new Guid ("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+
+		public static bool IsPortablePdb (string pdbFileName)
+		{
+			if (string.IsNullOrEmpty (pdbFileName) || !File.Exists (pdbFileName))
+				return false;
+			using (var file = new FileStream (pdbFileName, FileMode.Open)) {
+				var data = new byte [4];
+				int read = file.Read (data, 0, data.Length);
+				return read == 4 && BitConverter.ToUInt32 (data, 0) == 0x424a5342;
+			}
+		}
+
+		private string pdbFileName;
+
+		public PortablePdbData (string pdbFileName)
+		{
+			this.pdbFileName = pdbFileName;
+		}
+
+		internal class SoftScope
+		{
+			public int LiveRangeStart;
+
+			public int LiveRangeEnd;
+		}
+
+		// We need proxy method to make sure VS2013/15 doesn't crash(this method won't be called if portable .pdb file doesn't exist, which means 2017+)
+		[MethodImpl (MethodImplOptions.NoInlining)]
+		internal SoftScope [] GetHoistedScopes (MethodMirror method) => GetHoistedScopesPrivate (method);
+
+		internal SoftScope [] GetHoistedScopesPrivate (MethodMirror method)
+		{
+			using (var fs = new FileStream (pdbFileName, FileMode.Open))
+			using (var metadataReader = MetadataReaderProvider.FromPortablePdbStream (fs)) {
+				var reader = metadataReader.GetMetadataReader ();
+				var methodHandle = MetadataTokens.MethodDefinitionHandle (method.MetadataToken);
+				var customDebugInfos = reader.GetCustomDebugInformation (methodHandle);
+				foreach (var item in customDebugInfos) {
+					var debugInfo = reader.GetCustomDebugInformation (item);
+					if (reader.GetGuid (debugInfo.Kind) == StateMachineHoistedLocalScopes) {
+						var bytes = reader.GetBlobBytes (debugInfo.Value);
+						var result = new SoftScope [bytes.Length / 8];
+						for (int i = 0; i < bytes.Length; i += 8) {
+							var offset = BitConverter.ToInt32 (bytes, i);
+							var len = BitConverter.ToInt32 (bytes, i + 4);
+							result [i / 8] = new SoftScope () {
+								LiveRangeStart = offset,
+								LiveRangeEnd = offset + len
+							};
+						}
+						return result;
+					}
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1924,10 +1924,11 @@ namespace Mono.Debugging.Soft
 
 		void RegisterAssembly (AssemblyMirror asm)
 		{
-			if (domainAssembliesToUnload.TryGetValue (asm.Domain, out var asmList)) {
+			var domain = vm.Version.AtLeast (2, 45) ? asm.Domain : asm.GetAssemblyObject ().Domain;
+			if (domainAssembliesToUnload.TryGetValue (domain, out var asmList)) {
 				asmList.Add (asm);
 			} else {
-				domainAssembliesToUnload.Add (asm.Domain, new HashSet<AssemblyMirror> (new [] { asm }));
+				domainAssembliesToUnload.Add (domain, new HashSet<AssemblyMirror> (new [] { asm }));
 			}
 		}
 

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -752,6 +752,22 @@ namespace Mono.Debugging.Soft
 			return new [] { new ProcessInfo (procs[0].Id, procs[0].Name) };
 		}
 
+		internal PortablePdbData GetPdbData (AssemblyMirror asm)
+		{
+			string assemblyFileName;
+			if (!assemblyPathMap.TryGetValue (asm.GetName ().FullName, out assemblyFileName))
+				assemblyFileName = asm.Location;
+			var pdbFileName = Path.ChangeExtension (assemblyFileName, ".pdb");
+			if (!PortablePdbData.IsPortablePdb (pdbFileName))
+				return null;
+			return new PortablePdbData (pdbFileName);
+		}
+
+		internal PortablePdbData GetPdbData (MethodMirror method)
+		{
+			return GetPdbData (method.DeclaringType.Assembly);
+		}
+
 		protected override Backtrace OnGetThreadBacktrace (long processId, long threadId)
 		{
 			return GetThreadBacktrace (GetThread (threadId));

--- a/Mono.Debugging.Soft/packages.config
+++ b/Mono.Debugging.Soft/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net45" />
 </packages>

--- a/Mono.Debugging.Win32/Mono.Debugging.Win32.csproj
+++ b/Mono.Debugging.Win32/Mono.Debugging.Win32.csproj
@@ -35,13 +35,6 @@
     <DebugSymbols>true</DebugSymbols>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
@@ -110,9 +110,6 @@ namespace Mono.Debugging.Tests
 		[Test]
 		public void Bug33193 ()
 		{
-			var soft = Session as SoftDebuggerSession;
-			if (soft != null && soft.ProtocolVersion < new Version (2, 46))
-				Assert.Ignore ("A newer version of the Mono runtime is required.");
 			InitializeTest ();
 			AddBreakpoint ("f1665382-7ddc-4c65-9c20-39d4a0ae9cf1");
 			StartTest ("Bug33193Test");

--- a/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using Mono.Debugging.Soft;
 using NUnit.Framework;
 
 namespace Mono.Debugging.Tests


### PR DESCRIPTION
We need this changes in 15.3 because https://github.com/mono/mono/pull/4961 was reverted which means debugging will crash if runtime increases version this is fixed by a3e6bbe

I made regression on Unity debugging which needs fe58005 to fix it(it doesn't work at all)

This also fixes Bug 33193, even if it looks like minor bug(it's pretty old) this is new bug with Portable .pdb.

Changes by Marius are harmless...