### PR TITLE
Limited Lambda Support on Immediate Pad

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
@@ -112,6 +112,8 @@
     <Compile Include="Locale.cs" />
     <Compile Include="Mono.Debugger.Soft\PointerValue.cs" />
     <Compile Include="Mono.Debugger.Soft\LocalScope.cs" />
+    <Compile Include="Mono.Debugger.Soft\DelayedLambdaValue.cs" />
+    <Compile Include="Mono.Debugger.Soft\DelayedLambdaType.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ArrayMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ArrayMirror.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -90,6 +91,14 @@ namespace Mono.Debugger.Soft
 			if (index < 0 || index > Length - values.Length)
 				throw new IndexOutOfRangeException ();
 			vm.conn.Array_SetValues (id, index, vm.EncodeValues (values));
+		}
+
+		public void SetByteValues (byte[] bytes)
+		{
+			if (bytes != null && bytes.Length != Length) {
+				throw new IndexOutOfRangeException ();
+			}
+			vm.conn.ByteArray_SetValues (id, bytes);
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -2452,6 +2452,21 @@ namespace Mono.Debugger.Soft
 			SendReceive (CommandSet.ARRAY_REF, (int)CmdArrayRef.SET_VALUES, new PacketWriter ().WriteId (id).WriteInt (index).WriteInt (values.Length).WriteValues (values));
 		}
 
+		// This is a special case when setting values of an array that
+		// consists of a large number of bytes. This saves much time and
+		// cost than we create ValueImpl object for each byte.
+		internal void ByteArray_SetValues (long id, byte[] bytes)
+		{
+			int index = 0;
+			var typ = (byte)ElementType.U1;
+			var w = new PacketWriter ().WriteId (id).WriteInt (index).WriteInt (bytes.Length);
+			for (int i = 0; i < bytes.Length; i++) {
+				w.WriteByte (typ);
+				w.WriteInt (bytes[i]);
+			}
+			SendReceive (CommandSet.ARRAY_REF, (int)CmdArrayRef.SET_VALUES, w);
+		}
+
 		/*
 		 * STRINGS
 		 */

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaType.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaType.cs
@@ -17,11 +17,13 @@ namespace Mono.Debugger.Soft
 		}
 
 		string expression;
+		Tuple<string, Value>[] locals;
 		string uniqueName;
 
-		public DelayedLambdaType (VirtualMachine vm, string expression) : base (vm, 0)
+		public DelayedLambdaType (VirtualMachine vm, Tuple<string, Value>[] locals, string expression) : base (vm, 0)
 		{
 			this.expression = expression;
+			this.locals = locals;
 			this.uniqueName = "Lambda" + Guid.NewGuid ().ToString ("N");
 		}
 
@@ -29,8 +31,24 @@ namespace Mono.Debugger.Soft
 			get { return expression; }
 		}
 
+		public Tuple<string, Value>[] Locals {
+			get {
+				if (locals == null)
+					return new Tuple<string, Value> [0];
+				return locals;
+			}
+		}
+
 		public string Name {
 			get { return uniqueName; }
+		}
+
+		public Value[] GetLocalValues ()
+		{
+			var vals = new Value [Locals.Length];
+			for (int i = 0; i < vals.Length; i++)
+				vals [i] = Locals [i].Item2;
+			return vals;
 		}
 
 		public bool IsAcceptableType (TypeMirror t)

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaType.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaType.cs
@@ -97,7 +97,7 @@ namespace Mono.Debugger.Soft
 			if (typ == null)
 				return null;
 
-			string fullName = typ.FullName;
+			string fullName = typ.FullName.Replace ('+', '.');
 			string nmespace = typ.Namespace == "" ? null : typ.Namespace;
 			string typeName = "";
 			string [] argTypeNames = null;
@@ -126,7 +126,7 @@ namespace Mono.Debugger.Soft
 			} else {
 				if (!rest.EndsWith (typ.Name, StringComparison.Ordinal))
 					throw new ArgumentException ("invalid");
-				typeName = rest.Replace ('+', '.');
+				typeName = rest;
 			}
 
 			ParsedType t = new ParsedType ();

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaType.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaType.cs
@@ -1,0 +1,152 @@
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Mono.Debugger.Soft
+{
+	// Represents a temporary type of a lambda expression.
+	// In order to determine the type of a lambda based on
+	// its context, type evaluation for it must be delayed.
+	public class DelayedLambdaType : Mirror
+	{
+		class ParsedType
+		{
+			public string nameSpace;
+			public string typeName;
+			public string [] argTypeNames;
+		}
+
+		string expression;
+		string uniqueName;
+
+		public DelayedLambdaType (VirtualMachine vm, string expression) : base (vm, 0)
+		{
+			this.expression = expression;
+			this.uniqueName = "Lambda" + Guid.NewGuid ().ToString ("N");
+		}
+
+		public string Expression {
+			get { return expression; }
+		}
+
+		public string Name {
+			get { return uniqueName; }
+		}
+
+		public bool IsAcceptableType (TypeMirror t)
+		{
+			return IsAcceptable (ParseFullName (t));
+		}
+
+		private bool IsAcceptable (ParsedType t)
+		{
+			return t != null;
+		}
+
+		public string GetLiteralType (TypeMirror typ)
+		{
+			ParsedType t = ParseFullName (typ);
+			if (t == null || !IsAcceptable (t))
+				return null;
+			var ns = t.nameSpace != null ? t.nameSpace + "." : "";
+			var args = t.argTypeNames != null ? "<" + String.Join (",", t.argTypeNames) + ">" : "";
+
+			return ns + t.typeName + args;
+		}
+
+		private static ParsedType ParseFullName (TypeMirror t)
+		{
+			try {
+				return OnParseFullName (t);
+			} catch (Exception) {
+				return null;
+			}
+		}
+
+		private static ParsedType OnParseFullName (TypeMirror typ)
+		{
+			// Parse fullName of type to ParsedType that is defined above. Examples for the parsing
+			// are following.
+			// 1) System.Action`1[[System.Int32, mscorlib, Version=xxx, Culture=xxx,
+			//    PublicKeyToken=xxx]]
+			//  => { nameSpace: "System", typeName: "Action", argTypeNames: ["System.Int32"] }
+			// 2) System.Func`2[[System.Int32, mscorlib, Version=xxx, Culture=xxx,
+			//    PublicKeyToken=xxx],[System.Single, mscorlib, Version=xxx, Culture=xxx,
+			//    PublicKeyToken=xxx]]
+			//  => { nameSpace: "System", typeName: "Func",
+			//       argTypeNames: ["System.Int32", "System.Single"] }
+
+			if (typ == null)
+				return null;
+
+			string fullName = typ.FullName;
+			string nmespace = typ.Namespace == "" ? null : typ.Namespace;
+			string typeName = "";
+			string [] argTypeNames = null;
+
+			string rest = fullName;
+
+			if (nmespace != null) {
+				var omit = nmespace + ".";
+				if (!rest.StartsWith (omit, StringComparison.Ordinal)) {
+					throw new ArgumentException ("should starts with namespace");
+				}
+				rest = rest.Substring (omit.Length, rest.Length - omit.Length);
+			}
+
+			string pattern = @"(.*?)`\d+(.*)";
+			Match m = Regex.Match (rest, pattern);
+			if (m.Success) {
+				typeName = m.Groups [1].Value;
+				rest = m.Groups [2].Value;
+
+				int len = rest.Length;
+				if (rest [0] != '[' || rest [len - 1] != ']')
+					throw new ArgumentException ("Failed to skip braces");
+				rest = rest.Substring (1, len - 2);
+				argTypeNames = ReadArgTypeNames (rest);
+			} else {
+				if (!rest.EndsWith (typ.Name, StringComparison.Ordinal))
+					throw new ArgumentException ("invalid");
+				typeName = rest.Replace ('+', '.');
+			}
+
+			ParsedType t = new ParsedType ();
+			t.nameSpace = nmespace;
+			t.typeName = typeName;
+			t.argTypeNames = argTypeNames;
+
+			return t;
+		}
+
+		private static string [] ReadArgTypeNames (string s)
+		{
+			List<string> args = new List<string> ();
+			int nest = 0;
+			int start = 0;
+			for (int i = 0; i < s.Length; i++) {
+				char c = s [i];
+				if (c == '[') {
+					if (nest == 0)
+						start = i;
+					nest++;
+				} else if (c == ']') {
+					if (nest == 1)
+						args.Add (s.Substring (start, i - start + 1));
+					nest--;
+				}
+			}
+			string [] result = new string [args.Count];
+			int n = 0;
+			foreach (string arg in args) {
+				string pattern = @"\[(.*?)[,\]]";
+				Match m = Regex.Match (arg, pattern);
+				if (!m.Success)
+					throw new ArgumentException ("Failed to parse arg's names");
+				result [n] = m.Groups [1].Value;
+				n++;
+			}
+			return result;
+		}
+	}
+}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaValue.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaValue.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Mono.Debugger.Soft
 {
@@ -6,9 +7,9 @@ namespace Mono.Debugger.Soft
 	{
 		DelayedLambdaType delayedType;
 
-		public DelayedLambdaValue (VirtualMachine vm, string expression) : base (vm, 0)
+		public DelayedLambdaValue (VirtualMachine vm, Tuple<string, Value>[] locals, string expression) : base (vm, 0)
 		{
-			this.delayedType = new DelayedLambdaType (vm, expression);
+			this.delayedType = new DelayedLambdaType (vm, locals, expression);
 		}
 
 		public string Expression {
@@ -21,6 +22,15 @@ namespace Mono.Debugger.Soft
 
 		public string Name {
 			get { return DelayedType.Name; }
+		}
+
+		public Tuple<string, Value>[] Locals {
+			get { return DelayedType.Locals; }
+		}
+
+		public Value[] GetLocalValues ()
+		{
+			return DelayedType.GetLocalValues ();
 		}
 
 		public string GetLiteralType (TypeMirror t)

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaValue.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/DelayedLambdaValue.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Mono.Debugger.Soft
+{
+	public class DelayedLambdaValue : Value
+	{
+		DelayedLambdaType delayedType;
+
+		public DelayedLambdaValue (VirtualMachine vm, string expression) : base (vm, 0)
+		{
+			this.delayedType = new DelayedLambdaType (vm, expression);
+		}
+
+		public string Expression {
+			get { return DelayedType.Expression; }
+		}
+
+		public DelayedLambdaType DelayedType {
+			get { return delayedType; }
+		}
+
+		public string Name {
+			get { return DelayedType.Name; }
+		}
+
+		public string GetLiteralType (TypeMirror t)
+		{
+			return delayedType.GetLiteralType (t);
+		}
+
+		public bool IsAcceptableType (TypeMirror toType)
+		{
+			return delayedType.IsAcceptableType (toType);
+		}
+
+		public override string ToString ()
+		{
+			return string.Format ("LambdaValue for ({0})", Expression);
+		}
+	}
+}

--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -89,6 +89,42 @@
       <HintPath>$(SolutionDir)\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Composition.AttributedModel">
+      <HintPath>$(SolutionDir)\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Convention">
+      <HintPath>$(SolutionDir)\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Hosting">
+      <HintPath>$(SolutionDir)\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Runtime">
+      <HintPath>$(SolutionDir)\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts">
+      <HintPath>$(SolutionDir)\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="..\Mono.Debugging.settings" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -39,6 +39,9 @@ using Mono.Debugging.Backend;
 using Mono.Debugging.Evaluation;
 using Mono.Debugging.Client;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
 namespace Mono.Debugging.Soft
 {
 	public class SoftDebuggerAdaptor : ObjectValueAdaptor
@@ -335,7 +338,10 @@ namespace Mono.Debugging.Soft
 
 			if (val == null)
 				return null;
-			
+
+			if (val is DelayedLambdaValue)
+				return CompileAndLoadLambdaValue(cx, (DelayedLambdaValue)val, toType, out _);
+
 			var valueType = GetValueType (ctx, val);
 
 			fromType = valueType as TypeMirror;
@@ -530,6 +536,12 @@ namespace Mono.Debugging.Soft
 			return cx.Session.VirtualMachine.CreateValue (value);
 		}
 
+		public override object CreateDelayedLambdaValue (EvaluationContext ctx, string expression)
+		{
+			var soft = (SoftEvaluationContext)ctx;
+			return new DelayedLambdaValue (soft.Session.VirtualMachine, expression);
+		}
+
 		public object CreateByteArray (EvaluationContext ctx, byte [] byts)
 		{
 			var arrayType = GetType (ctx, "System.Array");
@@ -548,6 +560,131 @@ namespace Mono.Debugging.Soft
 				return arr;
 			}
 			return null;
+		}
+
+		private object CompileAndLoadLambdaValue (SoftEvaluationContext ctx, DelayedLambdaValue val, TypeMirror toType, out string compileError)
+		{
+			if (!val.IsAcceptableType (toType)) {
+				compileError = null;
+				return null;
+			}
+
+			string id = Guid.NewGuid ().ToString ("N");
+			string className = "Lambda" + id;
+			string typeName = val.GetLiteralType (toType);
+			byte [] bytes = CompileLambdaExpression (ctx, val.DelayedType, typeName, out compileError);
+
+			return LoadLambdaValue (ctx, val.DelayedType, bytes);
+		}
+
+		private Compilation CreateLibraryCompilation (SoftEvaluationContext ctx, string assemblyName, bool enableOptimisations)
+		{
+			// Add references to assembly of debugee
+			var assems = ctx.Domain.GetAssemblies ();
+			var references = new List<MetadataReference> ();
+			foreach (var assem in assems) {
+				try {
+					var location = assem.Location;
+					if (System.IO.Path.IsPathRooted (location)) {
+						var meta = MetadataReference.CreateFromFile (location);
+						references.Add (meta);
+					}
+				} catch (ArgumentException) {
+					// When assembly location path is invalid.
+					continue;
+				}
+			}
+
+			var options = new CSharpCompilationOptions (
+				OutputKind.DynamicallyLinkedLibrary,
+				optimizationLevel: enableOptimisations ? OptimizationLevel.Release : OptimizationLevel.Debug);
+
+			return CSharpCompilation.Create (assemblyName, options: options)
+									.AddReferences (references);
+		}
+
+		private byte [] CompileLambdaExpression (SoftEvaluationContext ctx, DelayedLambdaType val, string typeName, out string error)
+		{
+			string className = val.Name;
+			string assemblyNamePrefix = "lambdaAssem";
+			string assemblyName = assemblyNamePrefix + className;
+			string lambdaExpression = val.Expression;
+
+			int startOfExp, endOfExp;
+			error = null;
+
+			var sb = new System.Text.StringBuilder ();
+			sb.Append ("public class ");
+			sb.Append (className);
+			sb.Append ("{public static ");
+			sb.Append (typeName);
+			sb.Append (" injected_fn() {");
+			sb.Append ("return (");
+			startOfExp = sb.Length;
+			sb.Append (lambdaExpression);
+			endOfExp = startOfExp + lambdaExpression.Length;
+			sb.Append (");");
+			sb.Append ("}}");
+
+			var options = new CSharpParseOptions (kind: SourceCodeKind.Regular);
+			SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText (sb.ToString (), options);
+
+			IEnumerable<SyntaxTree> trees = new [] { syntaxTree };
+			Compilation compilation = CreateLibraryCompilation (ctx, assemblyName, true).AddSyntaxTrees (trees);
+
+			var stream = new System.IO.MemoryStream ();
+			var compileResult = compilation.Emit (stream);
+			if (compileResult.Success)
+				return stream.ToArray ();
+
+			// Take an error message only if its error is due to lambda expression that is
+			// inputted by user.
+			var diagnostics = compileResult.Diagnostics;
+			var dx = diagnostics.Length != 0 ? diagnostics [0] : null;
+
+			if (dx != null && dx.Severity == DiagnosticSeverity.Error) {
+				var location = dx.Location;
+				var start = location.SourceSpan.Start;
+				var end = location.SourceSpan.End;
+				if (startOfExp <= start && end <= endOfExp)
+					error = dx.GetMessage (System.Globalization.CultureInfo.InvariantCulture);
+			}
+			return null;
+		}
+
+		private object LoadLambdaValue (SoftEvaluationContext ctx, DelayedLambdaType typ, byte[] bytes)
+		{
+			if (bytes == null)
+				return null;
+
+			var assemblyType = ctx.Adapter.GetType (ctx, "System.Reflection.Assembly");
+			var byteArrayType = ctx.Adapter.GetType (ctx, "System.Byte[]");
+			var byteArrayValue = CreateByteArray (ctx, bytes);
+			var argTypes = new object[] { byteArrayType };
+			var argValues = new object[] { byteArrayValue };
+			var asm = ctx.Adapter.RuntimeInvoke (ctx, assemblyType, null, "Load", argTypes, argValues);
+
+			var stringType = ctx.Adapter.GetType (ctx, "System.String");
+			var classNameValue = ctx.Adapter.CreateValue (ctx, typ.Name);
+			argTypes = new object[] { stringType };
+			argValues = new object[] { classNameValue };
+			var injectedType = ctx.Adapter.RuntimeInvoke (ctx, assemblyType, asm, "GetType", argTypes, argValues);
+
+			var typeType = ctx.Adapter.GetType (ctx, "System.Type");
+			var methodNameValue = ctx.Adapter.CreateValue (ctx, "injected_fn");
+			argTypes = new object[] { stringType };
+			argValues = new object[] { methodNameValue };
+			var injectedFun = ctx.Adapter.RuntimeInvoke(ctx, typeType, injectedType, "GetMethod", argTypes, argValues);
+
+			var methodInfoType = ctx.Adapter.GetType (ctx, "System.Reflection.MethodInfo");
+			var objectType = ctx.Adapter.GetType (ctx, "System.Object");
+			var objectArrayType = ctx.Adapter.GetType (ctx, "System.Object[]");
+			var nullValue = ctx.Adapter.CreateValue (ctx, null);
+			var emptyArrayValue = ctx.Adapter.CreateArray (ctx, objectType, new object [] { });
+			argTypes = new object [] { objectType, objectArrayType };
+			argValues = new object [] { nullValue, emptyArrayValue };
+
+			return ctx.Adapter.RuntimeInvoke (ctx, methodInfoType, injectedFun, "Invoke", argTypes, argValues);
 		}
 
 		public override object GetBaseValue (EvaluationContext ctx, object val)
@@ -1602,6 +1739,8 @@ namespace Mono.Debugging.Soft
 				return ((StructMirror) val).Type;
 			if (val is PointerValue)
 				return ((PointerValue) val).Type;
+			if (val is DelayedLambdaValue)
+				return ((DelayedLambdaValue)val).DelayedType;
 			if (val is PrimitiveValue) {
 				var pv = (PrimitiveValue) val;
 				if (pv.Value == null)

--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -2326,10 +2326,20 @@ namespace Mono.Debugging.Soft
 				if (argTypes[i].IsDelayed)
 					continue;
 
-				int index = names.IndexOf (parameters[i].ParameterType.Name);
+				var paramType = parameters[i].ParameterType;
+				var isArray = paramType.IsArray;
+				if (isArray)
+					paramType = paramType.GetElementType ();
 
-				if (index != -1 && types[index] == null)
-					types[index] = argTypes[index];
+				int index = names.IndexOf (paramType.Name);
+
+				if (index != -1 && types[index] == null) {
+					var argType = argTypes[i].Type;
+					if (isArray && argType.IsArray)
+						argType = argType.GetElementType ();
+
+					types[index] = argType;
+				}
 			}
 
 			// make sure we have all the generic argument types...

--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -530,6 +530,26 @@ namespace Mono.Debugging.Soft
 			return cx.Session.VirtualMachine.CreateValue (value);
 		}
 
+		public object CreateByteArray (EvaluationContext ctx, byte [] byts)
+		{
+			var arrayType = GetType (ctx, "System.Array");
+			var int32Type = GetType (ctx, "System.Int32");
+			var typeType = GetType (ctx, "System.Type");
+			var stringType = GetType (ctx, "System.String");
+			var byteTypeValue = RuntimeInvoke (ctx, typeType, null, "GetType", new object [] { stringType }, new object [] { CreateValue (ctx, "System.Byte") });
+
+			var byteType = ctx.Adapter.GetType (ctx, "System.Byte");
+			var n = CreateValue (ctx, byts.Length);
+			var args = new object [] { byteTypeValue, n };
+			var arr = RuntimeInvoke (ctx, arrayType, null, "CreateInstance", new object [] { typeType, int32Type }, args);
+			if (arr is ArrayMirror) {
+				var arrm = arr as ArrayMirror;
+				arrm.SetByteValues (byts);
+				return arr;
+			}
+			return null;
+		}
+
 		public override object GetBaseValue (EvaluationContext ctx, object val)
 		{
 			return val;

--- a/Mono.Debugging.Soft/packages.config
+++ b/Mono.Debugging.Soft/packages.config
@@ -1,5 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeAnalysis" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net45" />

--- a/Mono.Debugging/Mono.Debugging.Evaluation/LambdaBodyOutputVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/LambdaBodyOutputVisitor.cs
@@ -1,0 +1,770 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Mono.Debugging.Client;
+
+using ICSharpCode.NRefactory.CSharp;
+
+namespace Mono.Debugging.Evaluation
+{
+	// Outputs lambda expression inputted on Immediate Pad. Also
+	// this class works for followings.
+	// - Check if body of lambda has not-supported expression
+	// - Output reserved words like `this` or `base` with generated
+	//   identifer.
+	// - Collect variable references for outside the lambda
+	//   (local variables/properties...)
+	public class LambdaBodyOutputVisitor : CSharpOutputVisitor
+	{
+		readonly Dictionary<string, ValueReference> userVariables;
+		readonly EvaluationContext ctx;
+
+		Dictionary<string, Tuple<string, object>> localValues;
+		List<string> definedIdentifier;
+		int gensymCount;
+
+		public LambdaBodyOutputVisitor (EvaluationContext ctx, Dictionary<string, ValueReference> userVariables, TextWriter writer) : base (writer, FormattingOptionsFactory.CreateMono ())
+		{
+			this.ctx = ctx;
+			this.userVariables = userVariables;
+			this.localValues = new Dictionary<string, Tuple<string, object>> ();
+			this.definedIdentifier = new List<string> ();
+		}
+
+		public Tuple<string, object>[] GetLocalValues ()
+		{
+			var locals = new Tuple<string, object>[localValues.Count];
+			int n = 0;
+			foreach(var localv in localValues.Values) {
+				locals [n] = localv;
+				n++;
+			}
+			return locals;
+		}
+
+		static Exception NotSupportedToConsistency ()
+		{
+			return new NotSupportedExpressionException ();
+		}
+
+		static Exception NotSupported ()
+		{
+			return new NotSupportedExpressionException ();
+		}
+
+		static Exception EvaluationError (string message, params object [] args)
+		{
+			return new EvaluatorException (message, args);
+		}
+
+		bool HasPublicType (ValueReference vr)
+		{
+			if (vr is NamespaceValueReference)
+				return true;
+
+			var typ = vr.Type;
+			return ctx.Adapter.IsPublic (ctx, typ);
+		}
+
+		bool HasPublicValue (ValueReference vr)
+		{
+			var isField = (vr.Flags & ObjectValueFlags.Field) != 0;
+			var isProperty = (vr.Flags & ObjectValueFlags.Property) != 0;
+			var isPublic = (vr.Flags & ObjectValueFlags.Public) != 0;
+
+			return !(isField || isProperty) || isPublic;
+		}
+
+		void AssertPublic (ValueReference vr)
+		{
+			if (!HasPublicType (vr)) {
+				var typeName = ctx.Adapter.GetDisplayTypeName (ctx, vr.Type);
+				throw EvaluationError ("Not Support to reference non-public type: `{0}'", typeName);
+			} else if (!HasPublicValue (vr)) {
+				throw EvaluationError ("Not Support to reference non-public thing: `{0}'", vr.Name);
+			}
+		}
+
+		ValueReference Evaluate (IdentifierExpression t)
+		{
+			var visitor = new NRefactoryExpressionEvaluatorVisitor (ctx, t.Identifier, null, userVariables);
+			return t.AcceptVisitor<ValueReference> (visitor);
+		}
+
+		ValueReference Evaluate (BaseReferenceExpression t)
+		{
+			var visitor = new NRefactoryExpressionEvaluatorVisitor (ctx, "base", null, userVariables);
+			return t.AcceptVisitor<ValueReference> (visitor);
+		}
+
+		ValueReference Evaluate (ThisReferenceExpression t)
+		{
+			var visitor = new NRefactoryExpressionEvaluatorVisitor (ctx, "this", null, userVariables);
+			return t.AcceptVisitor<ValueReference> (visitor);
+		}
+
+		string GenerateSymbol (string s)
+		{
+			var prefix = "__" + s;
+			var sym = prefix;
+			while (ExistsLocalName (sym)) {
+				sym = prefix + gensymCount++;
+			}
+
+			return sym;
+		}
+
+		string AddToLocals (string name, ValueReference vr, bool shouldRename = false)
+		{
+			if (localValues.ContainsKey (name))
+				return GetLocalName (name);
+
+			string localName;
+			if (shouldRename) {
+				localName = GenerateSymbol (name);
+			} else if (!ExistsLocalName (name)) {
+				localName = name;
+			} else {
+				throw EvaluationError ("Cannot use a variable named {0} inside lambda", name);
+			}
+
+			AssertPublic (vr);
+
+			var valu = vr != null ? vr.Value : null;
+			var pair = Tuple.Create (localName, valu);
+			localValues.Add (name, pair);
+			return localName;
+		}
+
+		string GetLocalName (string name)
+		{
+			Tuple<string, object> pair;
+			if (localValues.TryGetValue(name, out pair))
+				return pair.Item1;
+			return null;
+		}
+
+		bool ExistsLocalName (string localName)
+		{
+			foreach(var pair in localValues.Values) {
+				if (pair.Item1 == localName)
+					return true;
+			}
+			return definedIdentifier.Contains (localName);
+		}
+
+		#region IAstVisitor implementation
+
+		public override void VisitAnonymousMethodExpression (AnonymousMethodExpression anonymousMethodExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitUndocumentedExpression (UndocumentedExpression undocumentedExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitArrayCreateExpression (ArrayCreateExpression arrayCreateExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitArrayInitializerExpression (ArrayInitializerExpression arrayInitializerExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitAsExpression (AsExpression asExpression)
+		{
+		}
+		*/
+		public override void VisitAssignmentExpression (AssignmentExpression assignmentExpression)
+		{
+			throw EvaluationError ("Not support assignment expression inside lambda");
+		}
+
+		public override void VisitBaseReferenceExpression (BaseReferenceExpression baseReferenceExpression)
+		{
+			StartNode (baseReferenceExpression);
+			var basee = "base";
+			var localbase = GetLocalName(basee);
+			if (localbase == null) {
+				var vr = Evaluate (baseReferenceExpression);
+				localbase = AddToLocals (basee, vr, true);
+			}
+			WriteKeyword (localbase);
+			EndNode (baseReferenceExpression);
+		}
+		/*
+		public override void VisitBinaryOperatorExpression (BinaryOperatorExpression binaryOperatorExpression)
+		{
+		}
+		*//*
+		public override void VisitCastExpression (CastExpression castExpression)
+		{
+		}
+		*/
+		public override void VisitCheckedExpression (CheckedExpression checkedExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitConditionalExpression (ConditionalExpression conditionalExpression)
+		{
+		}
+		*/
+		public override void VisitDefaultValueExpression (DefaultValueExpression defaultValueExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitDirectionExpression (DirectionExpression directionExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitIdentifierExpression (IdentifierExpression identifierExpression)
+		{
+			StartNode (identifierExpression);
+			var identifier = identifierExpression.Identifier;
+			var localIdentifier = "";
+
+			if (definedIdentifier.Contains (identifier)) {
+				localIdentifier = identifier;
+			} else {
+				localIdentifier = GetLocalName (identifier);
+				if (localIdentifier == null) {
+					var vr = Evaluate (identifierExpression);
+					localIdentifier = AddToLocals (identifier, vr);
+				}
+			}
+			var idToken = identifierExpression.IdentifierToken;
+			idToken.Name = localIdentifier;
+			WriteIdentifier (idToken);
+			WriteTypeArguments (identifierExpression.TypeArguments);
+			EndNode (identifierExpression);
+		}
+		/*
+		public override void VisitIndexerExpression (IndexerExpression indexerExpression)
+		{
+		}
+		*//*
+		public override void VisitInvocationExpression (InvocationExpression invocationExpression)
+		{
+		}
+		*//*
+		public override void VisitIsExpression (IsExpression isExpression)
+		{
+		}*/
+
+		public override void VisitLambdaExpression (LambdaExpression lambdaExpression)
+		{
+			foreach (var par in lambdaExpression.Parameters) {
+				if (par.ParameterModifier != ICSharpCode.NRefactory.CSharp.ParameterModifier.None)
+					throw NotSupported();
+
+				definedIdentifier.Add(par.Name);
+			}
+
+			base.VisitLambdaExpression (lambdaExpression);
+		}
+		/*
+		public override void VisitMemberReferenceExpression (MemberReferenceExpression memberReferenceExpression)
+		{
+		}*/
+
+		public override void VisitNamedArgumentExpression (NamedArgumentExpression namedArgumentExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitNamedExpression (NamedExpression namedExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitNullReferenceExpression (NullReferenceExpression nullReferenceExpression)
+		{
+		}
+		*//*
+		public override void VisitObjectCreateExpression (ObjectCreateExpression objectCreateExpression)
+		{
+		}*/
+
+		public override void VisitAnonymousTypeCreateExpression (AnonymousTypeCreateExpression anonymousTypeCreateExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitParenthesizedExpression (ParenthesizedExpression parenthesizedExpression)
+		{
+		}*/
+
+		public override void VisitPointerReferenceExpression (PointerReferenceExpression pointerReferenceExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitPrimitiveExpression (PrimitiveExpression primitiveExpression)
+		{
+			return primitiveExpression.ToString ();
+		}*/
+
+		public override void VisitSizeOfExpression (SizeOfExpression sizeOfExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitStackAllocExpression (StackAllocExpression stackAllocExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitThisReferenceExpression (ThisReferenceExpression thisReferenceExpression)
+		{
+			StartNode (thisReferenceExpression);
+			var thiss = "this";
+			var localthis = GetLocalName (thiss);
+			if (localthis == null) {
+				var vr = Evaluate (thisReferenceExpression);
+				localthis = AddToLocals (thiss, vr, true);
+			}
+			WriteKeyword (localthis);
+			EndNode (thisReferenceExpression);
+		}
+		/*
+		public override void VisitTypeOfExpression (TypeOfExpression typeOfExpression)
+		{
+		}*/
+		/*
+		public override void VisitTypeReferenceExpression (TypeReferenceExpression typeReferenceExpression)
+		{
+		}*//*
+		public override void VisitUnaryOperatorExpression (UnaryOperatorExpression unaryOperatorExpression)
+		{
+		}*/
+
+		public override void VisitUncheckedExpression (UncheckedExpression uncheckedExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryExpression (QueryExpression queryExpression)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryContinuationClause (QueryContinuationClause queryContinuationClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryFromClause (QueryFromClause queryFromClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryLetClause (QueryLetClause queryLetClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryWhereClause (QueryWhereClause queryWhereClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryJoinClause (QueryJoinClause queryJoinClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryOrderClause (QueryOrderClause queryOrderClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryOrdering (QueryOrdering queryOrdering)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQuerySelectClause (QuerySelectClause querySelectClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitQueryGroupClause (QueryGroupClause queryGroupClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitAttribute (ICSharpCode.NRefactory.CSharp.Attribute attribute)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitAttributeSection (AttributeSection attributeSection)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitDelegateDeclaration (DelegateDeclaration delegateDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitNamespaceDeclaration (NamespaceDeclaration namespaceDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitTypeDeclaration (TypeDeclaration typeDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitUsingAliasDeclaration (UsingAliasDeclaration usingAliasDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitUsingDeclaration (UsingDeclaration usingDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitExternAliasDeclaration (ExternAliasDeclaration externAliasDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitBlockStatement (BlockStatement blockStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitBreakStatement (BreakStatement breakStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitCheckedStatement (CheckedStatement checkedStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitContinueStatement (ContinueStatement continueStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitDoWhileStatement (DoWhileStatement doWhileStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitEmptyStatement (EmptyStatement emptyStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitExpressionStatement (ExpressionStatement expressionStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitFixedStatement (FixedStatement fixedStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitForeachStatement (ForeachStatement foreachStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitForStatement (ForStatement forStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitGotoCaseStatement (GotoCaseStatement gotoCaseStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitGotoDefaultStatement (GotoDefaultStatement gotoDefaultStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitGotoStatement (GotoStatement gotoStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitIfElseStatement (IfElseStatement ifElseStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitLabelStatement (LabelStatement labelStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitLockStatement (LockStatement lockStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitReturnStatement (ReturnStatement returnStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitSwitchStatement (SwitchStatement switchStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitSwitchSection (SwitchSection switchSection)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitCaseLabel (CaseLabel caseLabel)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitThrowStatement (ThrowStatement throwStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitTryCatchStatement (TryCatchStatement tryCatchStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitCatchClause (CatchClause catchClause)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitUncheckedStatement (UncheckedStatement uncheckedStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitUnsafeStatement (UnsafeStatement unsafeStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitUsingStatement (UsingStatement usingStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitVariableDeclarationStatement (VariableDeclarationStatement variableDeclarationStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitWhileStatement (WhileStatement whileStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitYieldBreakStatement (YieldBreakStatement yieldBreakStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitYieldReturnStatement (YieldReturnStatement yieldReturnStatement)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitAccessor (Accessor accessor)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitConstructorDeclaration (ConstructorDeclaration constructorDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitConstructorInitializer (ConstructorInitializer constructorInitializer)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitDestructorDeclaration (DestructorDeclaration destructorDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitEnumMemberDeclaration (EnumMemberDeclaration enumMemberDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitEventDeclaration (EventDeclaration eventDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitCustomEventDeclaration (CustomEventDeclaration customEventDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitFieldDeclaration (FieldDeclaration fieldDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitIndexerDeclaration (IndexerDeclaration indexerDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitMethodDeclaration (MethodDeclaration methodDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitOperatorDeclaration (OperatorDeclaration operatorDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitParameterDeclaration (ParameterDeclaration parameterDeclaration)
+		{
+			if (parameterDeclaration.Parent is LambdaExpression)
+				base.VisitParameterDeclaration (parameterDeclaration);
+			else
+				throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitPropertyDeclaration (PropertyDeclaration propertyDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitVariableInitializer (VariableInitializer variableInitializer)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitFixedFieldDeclaration (FixedFieldDeclaration fixedFieldDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitFixedVariableInitializer (FixedVariableInitializer fixedVariableInitializer)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitSyntaxTree (SyntaxTree syntaxTree)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitSimpleType (SimpleType simpleType)
+		{
+		}*/
+		/*
+		public override void VisitMemberType (MemberType memberType)
+		{
+		}*/
+		/*
+		public override void VisitComposedType (ComposedType composedType)
+		{
+		}*/
+
+		public override void VisitArraySpecifier (ArraySpecifier arraySpecifier)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitPrimitiveType (PrimitiveType primitiveType)
+		{
+		}*/
+
+		public override void VisitComment (Comment comment)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitWhitespace (WhitespaceNode whitespaceNode)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitText (TextNode textNode)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitNewLine (NewLineNode newLineNode)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitPreProcessorDirective (PreProcessorDirective preProcessorDirective)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitDocumentationReference (DocumentationReference documentationReference)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitTypeParameterDeclaration (TypeParameterDeclaration typeParameterDeclaration)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitConstraint (Constraint constraint)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitCSharpTokenNode (CSharpTokenNode cSharpTokenNode)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitIdentifier (Identifier identifier)
+		{
+			throw NotSupportedToConsistency ();
+		}
+
+		public override void VisitPatternPlaceholder (AstNode placeholder, ICSharpCode.NRefactory.PatternMatching.Pattern pattern)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		/*
+		public override void VisitNullNode (AstNode nullNode)
+		{
+			throw NotSupportedToConsistency ();
+		}
+		*//*
+		public override void VisitErrorNode (AstNode errorNode)
+		{
+			throw NotSupportedToConsistency ();
+		}*/
+
+		#endregion
+	}
+}

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -530,6 +530,19 @@ namespace Mono.Debugging.Evaluation
 			throw ParseError ("Could not resolve type: {0}", ResolveTypeName (type));
 		}
 
+		static object[] UpdateDelayedTypes (object[] types, Tuple<int, object>[] updates, ref bool alreadyUpdated)
+		{
+			if (alreadyUpdated || types == null || updates == null || types.Length < updates.Length || updates.Length == 0)
+				return types;
+
+			for (int x = 0; x < updates.Length; x++) {
+				int index = updates[x].Item1;
+				types[index] = updates[x].Item2;
+			}
+			alreadyUpdated = true;
+			return types;
+		}
+
 		#region IAstVisitor implementation
 
 		public ValueReference VisitAnonymousMethodExpression (AnonymousMethodExpression anonymousMethodExpression)
@@ -856,6 +869,7 @@ namespace Mono.Debugging.Evaluation
 				throw new ImplicitEvaluationDisabledException ();
 
 			bool invokeBaseMethod = false;
+			bool allArgTypesAreResolved = true;
 			ValueReference target = null;
 			string methodName;
 
@@ -868,9 +882,14 @@ namespace Mono.Debugging.Evaluation
 				var vref = arg.AcceptVisitor<ValueReference> (this);
 				args[n] = vref.Value;
 				types[n] = ctx.Adapter.GetValueType (ctx, args[n]);
+
+				if (ctx.Adapter.IsDelayedType (ctx, types[n]))
+					allArgTypesAreResolved = false;
 				n++;
 			}
 			object vtype = null;
+			Tuple<int, object>[] resolvedLambdaTypes;
+
 			if (invocationExpression.Target is MemberReferenceExpression) {
 				var field = (MemberReferenceExpression) invocationExpression.Target;
 				target = field.Target.AcceptVisitor<ValueReference> (this);
@@ -908,9 +927,13 @@ namespace Mono.Debugging.Evaluation
 				vtype = target != null ? target.Type : ctx.Adapter.GetEnclosingType (ctx);
 			object vtarget = (target is TypeValueReference) || target == null ? null : target.Value;
 
+			var hasMethod = ctx.Adapter.HasMethod (ctx, vtype, methodName, typeArgs, types, BindingFlags.Instance | BindingFlags.Static, out resolvedLambdaTypes);
+			if (hasMethod)
+				types = UpdateDelayedTypes (types, resolvedLambdaTypes, ref allArgTypesAreResolved);
+
 			if (invokeBaseMethod) {
 				vtype = ctx.Adapter.GetBaseType (ctx, vtype);
-			} else if (target != null && !ctx.Adapter.HasMethod (ctx, vtype, methodName, typeArgs, types, BindingFlags.Instance | BindingFlags.Static)) {
+			} else if (target != null && !hasMethod) {
 				// Look for LINQ extension methods...
 				var linq = ctx.Adapter.GetType (ctx, "System.Linq.Enumerable");
 				if (linq != null) {
@@ -935,16 +958,25 @@ namespace Mono.Debugging.Evaluation
 						Array.Copy (args, 0, xargs, 1, args.Length);
 						xargs[0] = vtarget;
 
-						if (ctx.Adapter.HasMethod (ctx, linq, methodName, xtypeArgs, xtypes, BindingFlags.Static)) {
+						if (ctx.Adapter.HasMethod (ctx, linq, methodName, xtypeArgs, xtypes, BindingFlags.Static, out resolvedLambdaTypes)) {
 							vtarget = null;
 							vtype = linq;
 
 							typeArgs = xtypeArgs;
-							types = xtypes;
+							types = UpdateDelayedTypes (xtypes, resolvedLambdaTypes, ref allArgTypesAreResolved);
 							args = xargs;
 						}
 					}
 				}
+			}
+
+			if (!allArgTypesAreResolved) {
+				// TODO: Show detailed error message for why lambda types were not
+				// resolved. Major causes are:
+				// 1. there is no matched method
+				// 2. matched method exists, but the lambda body has some invalid
+				// expressions and does not compile
+				throw NotSupported ();
 			}
 
 			object result = ctx.Adapter.RuntimeInvoke (ctx, vtype, vtarget, methodName, typeArgs, types, args);
@@ -982,7 +1014,7 @@ namespace Mono.Debugging.Evaluation
 			while (parent != null && parent is ParenthesizedExpression)
 				parent = parent.Parent;
 
-			if (parent is CastExpression) {
+			if (parent is InvocationExpression || parent is CastExpression) {
 				object val = ctx.Adapter.CreateDelayedLambdaValue (ctx, lambdaExpression.ToString ());
 				if (val != null)
 					return LiteralValueReference.CreateTargetObjectLiteral (ctx, expression, val);

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -949,6 +949,10 @@ namespace Mono.Debugging.Evaluation
 							xtypeArgs = ctx.Adapter.GetTypeArgs (ctx, xtype);
 					}
 
+					if (xtypeArgs == null && ctx.Adapter.IsArray (ctx, target.Value)) {
+						xtypeArgs = new object [] { ctx.Adapter.CreateArrayAdaptor (ctx, target.Value).ElementType };
+					}
+
 					if (xtypeArgs != null) {
 						var xtypes = new object[types.Length + 1];
 						Array.Copy (types, 0, xtypes, 1, types.Length);

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -902,7 +902,7 @@ namespace Mono.Debugging.Evaluation
 
 				methodName = ResolveMethodName (method, out typeArgs);
 
-				if (vref != null && ctx.Adapter.HasMethod (ctx, vref.Type, methodName, typeArgs, null, BindingFlags.Instance)) {
+				if (vref != null && ctx.Adapter.HasMethod (ctx, vref.Type, methodName, typeArgs, types, BindingFlags.Instance)) {
 					vtype = ctx.Adapter.GetEnclosingType (ctx);
 					// There is an instance method for 'this', although it may not have an exact signature match. Check it now.
 					if (ctx.Adapter.HasMethod (ctx, vref.Type, methodName, typeArgs, types, BindingFlags.Instance)) {

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -1015,7 +1015,13 @@ namespace Mono.Debugging.Evaluation
 				parent = parent.Parent;
 
 			if (parent is InvocationExpression || parent is CastExpression) {
-				object val = ctx.Adapter.CreateDelayedLambdaValue (ctx, lambdaExpression.ToString ());
+				var writer = new System.IO.StringWriter ();
+				var visitor = new LambdaBodyOutputVisitor (ctx, userVariables, writer);
+
+				lambdaExpression.AcceptVisitor (visitor);
+				var body = writer.ToString ();
+				var values = visitor.GetLocalValues ();
+				object val = ctx.Adapter.CreateDelayedLambdaValue (ctx, body, values);
 				if (val != null)
 					return LiteralValueReference.CreateTargetObjectLiteral (ctx, expression, val);
 			}

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -949,8 +949,8 @@ namespace Mono.Debugging.Evaluation
 							xtypeArgs = ctx.Adapter.GetTypeArgs (ctx, xtype);
 					}
 
-					if (xtypeArgs == null && ctx.Adapter.IsArray (ctx, target.Value)) {
-						xtypeArgs = new object [] { ctx.Adapter.CreateArrayAdaptor (ctx, target.Value).ElementType };
+					if (xtypeArgs == null && ctx.Adapter.IsArray (ctx, vtarget)) {
+						xtypeArgs = new object [] { ctx.Adapter.CreateArrayAdaptor (ctx, vtarget).ElementType };
 					}
 
 					if (xtypeArgs != null) {

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -975,6 +975,19 @@ namespace Mono.Debugging.Evaluation
 
 		public ValueReference VisitLambdaExpression (LambdaExpression lambdaExpression)
 		{
+			if (lambdaExpression.IsAsync)
+				throw NotSupported ();
+
+			AstNode parent = lambdaExpression.Parent;
+			while (parent != null && parent is ParenthesizedExpression)
+				parent = parent.Parent;
+
+			if (parent is CastExpression) {
+				object val = ctx.Adapter.CreateDelayedLambdaValue (ctx, lambdaExpression.ToString ());
+				if (val != null)
+					return LiteralValueReference.CreateTargetObjectLiteral (ctx, expression, val);
+			}
+
 			throw NotSupported ();
 		}
 

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -427,6 +427,11 @@ namespace Mono.Debugging.Evaluation
 			return val;
 		}
 
+		public virtual object CreateDelayedLambdaValue (EvaluationContext ctx, string expression)
+		{
+			return null;
+		}
+
 		public virtual string[] GetImportedNamespaces (EvaluationContext ctx)
 		{
 			return new string[0];

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -376,6 +376,11 @@ namespace Mono.Debugging.Evaluation
 		{
 			return false;
 		}
+
+		public virtual bool IsPublic (EvaluationContext ctx, object type)
+		{
+			return false;
+		}
 		
 		public object GetType (EvaluationContext ctx, string name)
 		{
@@ -432,7 +437,7 @@ namespace Mono.Debugging.Evaluation
 			return val;
 		}
 
-		public virtual object CreateDelayedLambdaValue (EvaluationContext ctx, string expression)
+		public virtual object CreateDelayedLambdaValue (EvaluationContext ctx, string expression, Tuple<string, object>[] localVariables)
 		{
 			return null;
 		}

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -295,6 +295,11 @@ namespace Mono.Debugging.Evaluation
 		public abstract object[] GetTypeArgs (EvaluationContext ctx, object type);
 		public abstract object GetBaseType (EvaluationContext ctx, object type);
 
+		public virtual bool IsDelayedType (EvaluationContext ctx, object type)
+		{
+			return false;
+		}
+
 		public virtual bool IsGenericType (EvaluationContext ctx, object type)
 		{
 			return type != null && GetTypeName (ctx, type).IndexOf ('`') != -1;
@@ -1433,6 +1438,14 @@ namespace Mono.Debugging.Evaluation
 		// argTypes can be null, meaning that it has to return true if there is any method with that name
 		// flags will only contain Static or Instance flags
 		public abstract bool HasMethod (EvaluationContext ctx, object targetType, string methodName, object[] genericTypeArgs, object[] argTypes, BindingFlags flags);
+
+		// outarg `untyped lambda`
+		// if one of argtypes is untyped lambda, this will resolve its type.
+		public virtual bool HasMethod (EvaluationContext ctx, object targetType, string methodName, object[] genericTypeArgs, object[] argTypes, BindingFlags flags, out Tuple<int, object>[] resolvedLambdaTypes)
+		{
+			resolvedLambdaTypes = null;
+			return HasMethod (ctx, targetType, methodName, genericTypeArgs, argTypes, flags);
+		}
 
 		public object RuntimeInvoke (EvaluationContext ctx, object targetType, object target, string methodName, object[] argTypes, object[] argValues)
 		{

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -1418,6 +1418,11 @@ namespace Mono.Debugging.Evaluation
 			}
 		}
 
+		public virtual bool HasMethodWithParamLength (EvaluationContext ctx, object targetType, string methodName, BindingFlags flags, int paramLength)
+		{
+			return false;
+		}
+
 		public bool HasMethod (EvaluationContext ctx, object targetType, string methodName)
 		{
 			BindingFlags flags = BindingFlags.Instance | BindingFlags.Static;

--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Mono.Debugging.Client\DebuggerLoggingService.cs" />
     <Compile Include="Mono.Debugging.Client\RunToCursorBreakpoint.cs" />
     <Compile Include="Mono.Debugging.Evaluation\EnumerableElementGroup.cs" />
+    <Compile Include="Mono.Debugging.Evaluation\LambdaBodyOutputVisitor.cs" />
   </ItemGroup>
   <Import Project="..\Mono.Debugging.settings" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -764,6 +764,7 @@ namespace Mono.Debugging.Tests
 			}
 			Assert.AreEqual ("5000", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
+
 			val = Eval ("string.Join(\",\", numbers.Where(n=>n.StartsWith(\"t\")).ToArray())");
 			if (!AllowTargetInvokes) {
 				var options = Session.Options.EvaluationOptions.Clone ();

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -788,6 +788,30 @@ namespace Mono.Debugging.Tests
 			}
 			Assert.AreEqual ("{MonoDevelop.Debugger.Tests.TestApp.SomeOuterClass.SomeInnerClass}", val.Value);
 			Assert.AreEqual ("MonoDevelop.Debugger.Tests.TestApp.SomeOuterClass.SomeInnerClass", val.TypeName);
+
+			val = Eval ("System.Array.Find(instArray, x => x.n == 10)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("{MonoDevelop.Debugger.Tests.TestApp.SomeOuterClass.SomeInnerClass}", val.Value);
+			Assert.AreEqual ("MonoDevelop.Debugger.Tests.TestApp.SomeOuterClass.SomeInnerClass", val.TypeName);
+
+			val = Eval ("System.Array.FindIndex(numbers, x => x == \"one\") == System.Array.IndexOf(numbers, \"one\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("true", val.Value);
+			Assert.AreEqual ("bool", val.TypeName);
 		}
 
 		[Test]

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -556,6 +556,63 @@ namespace Mono.Debugging.Tests
 		}
 
 		[Test]
+		public void FuncInvoke ()
+		{
+			ObjectValue val;
+
+			var soft = Session as SoftDebuggerSession;
+			if (soft != null && soft.ProtocolVersion < new Version (2, 31))
+				Assert.Ignore ("A newer version of the Mono runtime is required.");
+
+			val = Eval ("((System.Action<int>)(x => System.Console.WriteLine(x))).Invoke(5)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("No return value.", val.Value);
+
+			val = Eval ("((System.Func<string,int>)(x => x.Length + 10)).Invoke(\"abcd\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("14", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("((System.Predicate<string>)(x => x == \"abcd\")).Invoke(\"abcd\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("true", val.Value);
+			Assert.AreEqual ("bool", val.TypeName);
+
+			val = Eval ("((MonoDevelop.Debugger.Tests.TestApp.del)((x, y) => x + y * 100 - 1)).Invoke(-9, 5)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("490", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+		}
+
+		[Test]
 		public void GenericMethodInvoke ()
 		{
 			var soft = Session as SoftDebuggerSession;

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -610,6 +610,136 @@ namespace Mono.Debugging.Tests
 			}
 			Assert.AreEqual ("490", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("stringList.Sum(x => x.Length)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("9", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("stringList.Any (x => x.Length == 3)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("true", val.Value);
+			Assert.AreEqual ("bool", val.TypeName);
+
+			val = Eval ("stringList.Last(x => x.CompareTo(\"c\") < 0)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"bbb\"", val.Value);
+			Assert.AreEqual ("string", val.TypeName);
+
+			val = Eval ("this.InvokeFuncInt (() => 100 + 500 * 2)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("1100", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("this.InvokeFuncString (() => \"test\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"test\"", val.Value);
+			Assert.AreEqual ("string", val.TypeName);
+
+			val = Eval ("testEvaluationChild.OverridenInvokeFuncInt(() => 100)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("101", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("testEvaluationChild.OverridenInvokeFuncString(() => \"test\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"test-in-overriden\"", val.Value);
+			Assert.AreEqual ("string", val.TypeName);
+
+			val = Eval ("this.OverloadedInvokeFunc (() => \"test\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"test\"", val.Value);
+			Assert.AreEqual ("string", val.TypeName);
+
+			val = Eval ("this.InvokePredicateString (x => x == \"abc\")");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("true", val.Value);
+			Assert.AreEqual ("bool", val.TypeName);
+
+			val = Eval ("this.InvokeUserDelegate ((x, y) => x + y)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("6", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("InvokeGenericFunc (500, x => x * 10");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("5000", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
 		}
 
 		[Test]

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -659,6 +659,18 @@ namespace Mono.Debugging.Tests
 			Assert.AreEqual ("1100", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
 
+			val = Eval ("this.InvokeFuncInt (() => this.HiddenField)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			// Error occurs beacause `this' type is non public
+			Assert.IsTrue (val.IsError);
+
 			val = Eval ("this.InvokeFuncString (() => \"test\")");
 			if (!AllowTargetInvokes) {
 				var options = Session.Options.EvaluationOptions.Clone ();
@@ -682,7 +694,7 @@ namespace Mono.Debugging.Tests
 			Assert.AreEqual ("101", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
 
-			val = Eval ("testEvaluationChild.OverridenInvokeFuncString(() => \"test\")");
+			val = Eval ("testEvaluationChild.OverridenInvokeFuncString(() => (stringList.Count < n ? stringList[1] : stringList[0]) + intOne)");
 			if (!AllowTargetInvokes) {
 				var options = Session.Options.EvaluationOptions.Clone ();
 				options.AllowTargetInvoke = true;
@@ -690,10 +702,10 @@ namespace Mono.Debugging.Tests
 				val.Refresh (options);
 				val = val.Sync ();
 			}
-			Assert.AreEqual ("\"test-in-overriden\"", val.Value);
+			Assert.AreEqual ("\"bbb1-in-overriden\"", val.Value);
 			Assert.AreEqual ("string", val.TypeName);
 
-			val = Eval ("this.OverloadedInvokeFunc (() => \"test\")");
+			val = Eval ("this.OverloadedInvokeFunc (() => dict.Count + 500)");
 			if (!AllowTargetInvokes) {
 				var options = Session.Options.EvaluationOptions.Clone ();
 				options.AllowTargetInvoke = true;
@@ -702,7 +714,19 @@ namespace Mono.Debugging.Tests
 				val.Refresh (options);
 				val = val.Sync ();
 			}
-			Assert.AreEqual ("\"test\"", val.Value);
+			Assert.AreEqual ("501", val.Value);
+			Assert.AreEqual ("int", val.TypeName);
+
+			val = Eval ("this.OverloadedInvokeFunc (() => \"\" + n + 5)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"325\"", val.Value);
 			Assert.AreEqual ("string", val.TypeName);
 
 			val = Eval ("this.InvokePredicateString (x => x == \"abc\")");

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -764,6 +764,17 @@ namespace Mono.Debugging.Tests
 			}
 			Assert.AreEqual ("5000", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
+			val = Eval ("string.Join(\",\", numbers.Where(n=>n.StartsWith(\"t\")).ToArray())");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"two,three\"", val.Value);
+			Assert.AreEqual ("string", val.TypeName);
 		}
 
 		[Test]

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -776,6 +776,18 @@ namespace Mono.Debugging.Tests
 			}
 			Assert.AreEqual ("\"two,three\"", val.Value);
 			Assert.AreEqual ("string", val.TypeName);
+
+			val = Eval ("instList.Find(x => x.n == 5)");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsImplicitNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("{MonoDevelop.Debugger.Tests.TestApp.SomeOuterClass.SomeInnerClass}", val.Value);
+			Assert.AreEqual ("MonoDevelop.Debugger.Tests.TestApp.SomeOuterClass.SomeInnerClass", val.TypeName);
 		}
 
 		[Test]

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -325,6 +325,7 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			var inst1 = new SomeOuterClass.SomeInnerClass (5);
 			var inst2 = new SomeOuterClass.SomeInnerClass (10);
 			var instList = new List<SomeOuterClass.SomeInnerClass> { inst1, inst2 };
+			var instArray = instList.ToArray ();
 
 			Bug57425.IEx bug57425 = new Bug57425.MainClass ();
 

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -189,6 +189,16 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 				return "6";
 			}
 		}
+
+		public override int OverridenInvokeFuncInt (Func<int> f)
+		{
+			return f () + 1;
+		}
+
+		public override string OverridenInvokeFuncString (Func<string> f)
+		{
+			return f () + "-in-overriden";
+		}
 	}
 
 	public abstract class BaseClass
@@ -387,6 +397,36 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			return a.ToString ();
 		}
 
+		public int InvokeFuncInt (Func<int> f)
+		{
+			return f ();
+		}
+
+		public string InvokeFuncString (Func<string> f)
+		{
+			return f ();
+		}
+
+		public bool InvokePredicateString (Predicate<string> f)
+		{
+			return f ("abc");
+		}
+
+		public int InvokeUserDelegate (del f)
+		{
+			return f (5, 1);
+		}
+
+		public int OverloadedInvokeFunc (Func<int> f)
+		{
+			return f ();
+		}
+
+		public string OverloadedInvokeFunc (Func<string> f)
+		{
+			return f ();
+		}
+
 		public string EscapedStrings {
 			get { return " \" \\ \a \b \f \v \n \r \t"; }
 		}
@@ -405,6 +445,11 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 				list.Add (value);
 			}
 			return list;
+		}
+
+		public static T InvokeGenericFunc<T> (T value, Func<T, T> f)
+		{
+			return f (value);
 		}
 
 		class NestedClass
@@ -451,6 +496,16 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			get {
 				return "5";
 			}
+		}
+
+		public virtual int OverridenInvokeFuncInt (Func<int> f)
+		{
+			return f ();
+		}
+
+		public virtual string OverridenInvokeFuncString (Func<string> f)
+		{
+			return f ();
 		}
 	}
 

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -123,6 +123,18 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 
 	public delegate int del (int x, int y);
 
+	public class SomeOuterClass
+	{
+		public class SomeInnerClass
+		{
+			public int n;
+			public SomeInnerClass(int n)
+			{
+				this.n = n;
+			}
+		}
+	}
+
 	class TestEvaluationParent
 	{
 		public int TestMethodBase ()
@@ -309,6 +321,10 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			FooBar = new FooBar ();
 			Foo = new FooBar ();
 			Bar = new FooBar ();
+
+			var inst1 = new SomeOuterClass.SomeInnerClass (5);
+			var inst2 = new SomeOuterClass.SomeInnerClass (10);
+			var instList = new List<SomeOuterClass.SomeInnerClass> { inst1, inst2 };
 
 			Bug57425.IEx bug57425 = new Bug57425.MainClass ();
 

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -121,6 +121,8 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 		}
 	}
 
+	public delegate int del (int x, int y);
+
 	class TestEvaluationParent
 	{
 		public int TestMethodBase ()


### PR DESCRIPTION
Support lambda expressions on expression evaluator.

#### Supported Features:
Lambdas satisfying the following conditions are supported.
* Lambdas with cast or method invocation
  - `((Action<string>)(x => System.Console.WriteLine (x))`
  - `(Func<int>)(() => 50 * 100)`
  - `lst.Find (x => x == “bar”)`
  - `arr.First (x => x == "foo")`
* Public type / public method / local variables access

#### Non-Supported Features:
1. Private type / private method access
2. Lambdas in some kinds of generic methods
    - Invocation of generic methods like `Method1<T> (T x, Func<T> f)` are supported because a generic type `T` can be resolved by the type of first parameter `x`.
    - However, this doesn’t work: `Method1<T> (Func<T> f)`
    - We have to provide type arguments like `Method1<int>(() => 50)`
3. Side Effect
    - `((Action<int>)(x => y = x)).Invoke(5)`, let y be one of local variables.
4. Async Lambdas

Note that my patches use Microsoft.CodeAnalysis ver1.3.2, while MonoDevelop references ver2.3.0-beta1. Ver-2.3.0 is not available under the target framework version 4.5. I'd like to ask reviewers if it's alright to update the target framework version.
