### PR TITLE
Bug 57721 - Show Value on Popup non-functional in this case

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
@@ -96,9 +96,11 @@ namespace Mono.Debugging.Evaluation
 		
 		public ObjectValue CreateObjectValue (EvaluationOptions options)
 		{
-			if (!CanEvaluate (options))
+			if (!CanEvaluate (options)) {
+				if (options.AllowTargetInvoke)//If it can't evaluate and target invoke is allowed, mark it as not supported.
+					return DC.ObjectValue.CreateNotSupported (this, new ObjectPath (Name), Context.Adapter.GetDisplayTypeName (GetContext (options), Type), "Can not evaluate", Flags);
 				return DC.ObjectValue.CreateImplicitNotSupported (this, new ObjectPath (Name), Context.Adapter.GetDisplayTypeName (GetContext (options), Type), Flags);
-			
+			}
 			Connect ();
 			try {
 				return OnCreateObjectValue (options);


### PR DESCRIPTION
Issue was that those properties were introduced in macOs 10.13 and user ran 10.12
But bug was that we treated that same as if ImplicitEvaluation was disabled, hence showing "Show Value" button meant to force evaluation even with ImplicitEvaluation disabled... But when "Show Value" was clicked it still didn't evaluate because that was not allowed...

This is how it looks now:
![image](https://user-images.githubusercontent.com/774791/28866957-db8deacc-7774-11e7-9e53-65f21bcc25e3.png)
