### PR TITLE
Bug 33166 - Exception spew in the application output when writing in the immediate window

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -785,6 +785,7 @@ namespace Mono.Debugging.Evaluation
 					}
 
 					// FIXME: handle types and namespaces...
+				} catch (EvaluatorException) {
 				} catch (Exception ex) {
 					ctx.WriteDebuggerError (ex);
 				}


### PR DESCRIPTION
Writing exceptions to "Application Output" caused by trying to get code completion makes no sense...