### PR TITLE
Fixed named tuples not working in some cases, when Roslyn starts with…

### DIFF
--- a/Mono.Debugging.Soft/PortablePdbData.cs
+++ b/Mono.Debugging.Soft/PortablePdbData.cs
@@ -125,8 +125,10 @@ namespace Mono.Debugging.Soft
 			using (var metadataReader = MetadataReaderProvider.FromPortablePdbStream (fs)) {
 				var reader = metadataReader.GetMetadataReader ();
 				var methodHandle = MetadataTokens.MethodDefinitionHandle (method.MetadataToken);
-				var methodInfo = reader.GetLocalScopes (methodHandle);
-				var localVar = methodInfo.Select (s => reader.GetLocalScope (s)).SelectMany (s => s.GetLocalVariables ()).Single (l => reader.GetLocalVariable (l).Index == localVariableIndex);
+				var localScopes = reader.GetLocalScopes (methodHandle);
+				// localVariableIndex is not really il_index, but sequential index when fetching locals
+				// hence use Skip(index) instead of Index matching.
+				var localVar = localScopes.Select (s => reader.GetLocalScope (s)).SelectMany (s => s.GetLocalVariables ()).Skip (localVariableIndex).First ();
 				var customDebugInfos = reader.GetCustomDebugInformation (localVar);
 				foreach (var item in customDebugInfos) {
 					var debugInfo = reader.GetCustomDebugInformation (item);

--- a/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
@@ -84,6 +84,19 @@ namespace Mono.Debugging.Tests
 		}
 
 		[Test]
+		public void NamedTupleIndexMissmatch ()
+		{
+			IgnoreCorDebugger ();
+			InitializeTest ();
+			AddBreakpoint ("9196deef-9d41-41d6-bcef-9e3ef58f9635");
+			StartTest ("NamedTupleIndexMissmatchTest");
+			CheckPosition ("9196deef-9d41-41d6-bcef-9e3ef58f9635");
+			var val = Eval ("item.xmlNs");
+			Assert.AreEqual ("\"test\"", val.Value);
+			Assert.AreEqual ("string", val.TypeName);
+		}
+
+		[Test]
 		public void Bug24998 ()
 		{
 			InitializeTest ();

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/AdvancedEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/AdvancedEvaluation.cs
@@ -87,6 +87,18 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			}
 		}
 
+		public class Tuples
+		{
+			public List<(string xmlNs, object clrNs)> Usings { get; set; } = new List<(string xmlNs, object clrNs)> () { ("test", null) };
+		}
+
+		public void NamedTupleIndexMissmatchTest ()
+		{
+			foreach (var item in new Tuples ().Usings) {
+				item.xmlNs.ToUpper ();/*9196deef-9d41-41d6-bcef-9e3ef58f9635*/
+			}
+		}
+
 		public void Bug24998Test ()
 		{
 			Bug24998 ().Wait ();


### PR DESCRIPTION
… il_index=1 instead 0