### PR TITLE
Fixed bug with typeof() which set wrong Type causing method invoking not working

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -1079,7 +1079,7 @@ namespace Mono.Debugging.Evaluation
 			if (result == null)
 				throw NotSupported ();
 
-			return LiteralValueReference.CreateTargetObjectLiteral (ctx, name, result, type);
+			return LiteralValueReference.CreateTargetObjectLiteral (ctx, name, result);
 		}
 
 		public ValueReference VisitTypeReferenceExpression (TypeReferenceExpression typeReferenceExpression)

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -366,6 +366,12 @@ namespace Mono.Debugging.Tests
 				val = val.Sync ();
 			}
 			Assert.AreEqual ("{System.Console}", val.Value);
+
+			if (!AllowTargetInvokes)
+				return;
+
+			val = Eval ("typeof(System.Console).GetMembers()");
+			Assert.AreEqual ("System.Reflection.MemberInfo[]", val.TypeName);
 		}
 
 		[Test]


### PR DESCRIPTION
e.g. `typeof(System.Console).GetMembers()` returning `GetMembers()` not member, reason is... `type` parameter that was passed was of type `System.Console` instead `System.Type` hence, bug
Also added unit test