### PR TITLE
Bug 48230 - Immediate window's autocompletion is case sensitive

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -776,7 +776,7 @@ namespace Mono.Debugging.Evaluation
 
 		public virtual CompletionData GetExpressionCompletionData (EvaluationContext ctx, string expr)
 		{
-			if (string.IsNullOrEmpty (expr))
+			if (expr == null)
 				return null;
 
 			int dot = expr.LastIndexOf ('.');
@@ -810,24 +810,20 @@ namespace Mono.Debugging.Evaluation
 				lastWastLetter = !char.IsDigit (c);
 			}
 
-			if (lastWastLetter) {
-				string partialWord = expr.Substring (i + 1);
-				
+			if (lastWastLetter || expr.Length == 0) {
 				var data = new CompletionData ();
-				data.ExpressionLength = partialWord.Length;
+				data.ExpressionLength = expr.Length - (i + 1);
 
 				// Local variables
 				
 				foreach (var vc in GetLocalVariables (ctx)) {
-					if (vc.Name.StartsWith (partialWord, StringComparison.InvariantCulture))
-						data.Items.Add (new CompletionItem (vc.Name, vc.Flags));
+					data.Items.Add (new CompletionItem (vc.Name, vc.Flags));
 				}
 
 				// Parameters
 				
 				foreach (var vc in GetParameters (ctx)) {
-					if (vc.Name.StartsWith (partialWord, StringComparison.InvariantCulture))
-						data.Items.Add (new CompletionItem (vc.Name, vc.Flags));
+					data.Items.Add (new CompletionItem (vc.Name, vc.Flags));
 				}
 
 				// Members
@@ -840,8 +836,7 @@ namespace Mono.Debugging.Evaluation
 				object type = GetEnclosingType (ctx);
 				
 				foreach (var vc in GetMembers (ctx, null, type, thisobj != null ? thisobj.Value : null)) {
-					if (vc.Name.StartsWith (partialWord, StringComparison.InvariantCulture))
-						data.Items.Add (new CompletionItem (vc.Name, vc.Flags));
+					data.Items.Add (new CompletionItem (vc.Name, vc.Flags));
 				}
 				
 				if (data.Items.Count > 0)

--- a/UnitTests/Mono.Debugging.Tests/Shared/CodeCompletionTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/CodeCompletionTests.cs
@@ -1,0 +1,78 @@
+﻿//
+// CodeCompletionTests.cs
+//
+// Author:
+//       David Karlaš <david.karlas@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Mono.Debugging.Tests;
+using MonoDevelop.Debugger;
+using NUnit.Framework;
+
+namespace Mono.Debugging.Tests
+{
+	namespace Soft
+	{
+		[TestFixture]
+		public class SdbCodeCompletionTests : CodeCompletionTests
+		{
+			public SdbCodeCompletionTests () : base ("Mono.Debugger.Soft")
+			{
+			}
+		}
+	}
+
+	namespace Win32
+	{
+		[TestFixture]
+		[Platform (Include = "Win")]
+		public class CorCodeCompletionTests : CodeCompletionTests
+		{
+			public CorCodeCompletionTests () : base ("MonoDevelop.Debugger.Win32")
+			{
+			}
+		}
+	}
+
+	[TestFixture]
+	public abstract class CodeCompletionTests : DebugTests
+	{
+		public CodeCompletionTests (string engineId) : base (engineId)
+		{
+		}
+
+		[TestFixtureSetUp]
+		public override void SetUp ()
+		{
+			base.SetUp ();
+
+			Start ("TestEvaluation");
+		}
+
+		[Test]
+		public void SimpleVariablesList ()
+		{
+			var completionData = Session.ActiveThread.Backtrace.GetFrame (0).GetExpressionCompletionData ("");
+			Assert.Less (0, completionData.Items.Count);
+		}
+	}
+}


### PR DESCRIPTION
This fixes also problem with fuzzy search not working... for example if user has variable "SomeVariable", and user types "V", it will show "SomeVariable", filtering is job of CodeCompletionWidget not completions provider...
Also added SimpleCodeCompletion unit test