### PR TITLE
InvalidOperationException ("Already connecting") at second connection attempt 

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -185,7 +185,7 @@ namespace Mono.Debugging.Soft
 				try {
 					if (timeBetweenAttempts > 0)
 						Thread.Sleep (timeBetweenAttempts);
-					ConnectionStarting (startArgs.ConnectionProvider.BeginConnect (dsi, callback), dsi, false, 0);
+					ConnectionStarting (startArgs.ConnectionProvider.BeginConnect (dsi, callback), dsi, false, attemptNumber);
 				} catch (Exception ex2) {
 					OnConnectionError (ex2);
 				}


### PR DESCRIPTION
I get **InvalidOperationException ("Already connecting")**, if first connection attempt fails.
Looks like it's because **0** is passed instead of **attemptNumber**.