### PR TITLE
Virtual Property always showing Base Value in Debugger

### DIFF
--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -2385,6 +2385,12 @@ namespace Mono.Debugging.Tests
 			}
 			Assert.AreEqual ("43", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
+
+			if (AllowTargetInvokes) {
+				val = Eval ("bar.Foo");
+				Assert.AreEqual ("MonoDevelop.Debugger.Tests.TestApp.BaseClass+MyEnum.Black", val.Value);
+				Assert.AreEqual ("MonoDevelop.Debugger.Tests.TestApp.BaseClass.MyEnum", val.TypeName);
+			}
 		}
 
 		[Test]

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -165,6 +165,20 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 		}
 	}
 
+	public abstract class BaseClass
+	{
+		public enum MyEnum
+		{
+			Red,
+			Black
+		}
+		public virtual MyEnum Foo { get; set; }
+	}
+	public class OverrideClass : BaseClass
+	{
+		public override MyEnum Foo { get { return MyEnum.Black; } set { throw new NotImplementedException(); }}
+	}
+
 	class TestEvaluation : TestEvaluationParent
 	{
 		static string staticString = "some static";
@@ -269,6 +283,7 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			int [] myBoundArray = new int [1] { Int32.MinValue };
 			Array myExtremeArray = Array.CreateInstance (typeof (String), myLengthArray, myBoundArray);
 			myExtremeArray.SetValue ("b38c0da4-a009-409d-bc78-2a051267d05a", int.MinValue + 1);
+			BaseClass bar = new OverrideClass();
 
 			Console.WriteLine (n); /*break*/
 		}


### PR DESCRIPTION
VSTS 546178 - https://developercommunity.visualstudio.com/content/problem/171231/virtual-property-always-showing-base-value-in-debu.html
Change in `HasMethod` method was made because one unit test started failing because wrong method overload was picked, hence making it more strict fixes that