### PR TITLE
Bug 525894 - Call Stack is empty when breakpoint is hit inside Parallel.Invoke

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -745,8 +745,12 @@ namespace Mono.Debugging.Soft
 		{
 			if (vthis == null)
 				return new ValueReference [0];
-			
-			object val = vthis.Value;
+			object val;
+			try {
+				val = vthis.Value;
+			} catch (EvaluatorException ex) when (ex.InnerException is AbsentInformationException) {
+				return new ValueReference [0];
+			}
 			if (IsNull (cx, val))
 				return new ValueReference [0];
 			

--- a/Mono.Debugging.Soft/VariableValueReference.cs
+++ b/Mono.Debugging.Soft/VariableValueReference.cs
@@ -98,8 +98,8 @@ namespace Mono.Debugging.Soft
 						value = batch != null ? batch.GetValue (variable) : ctx.Frame.GetValue (variable);
 
 					return NormalizeValue (ctx, value);
-				} catch (AbsentInformationException) {
-					throw new EvaluatorException ("Value not available");
+				} catch (AbsentInformationException ex) {
+					throw new EvaluatorException (ex, "Value not available");
 				} catch (ArgumentException ex) {
 					throw new EvaluatorException (ex.Message);
 				}

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ExpressionEvaluator.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ExpressionEvaluator.cs
@@ -207,6 +207,10 @@ namespace Mono.Debugging.Evaluation
 		public EvaluatorException (string msg, params object[] args): base (string.Format (msg, args))
 		{
 		}
+
+		public EvaluatorException (Exception innerException, string msg, params object [] args) : base (string.Format (msg, args), innerException)
+		{
+		}
 	}
 
 	[Serializable]

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
@@ -109,7 +109,7 @@ namespace Mono.Debugging.Evaluation
 			} catch (NotSupportedExpressionException ex) {
 				return DC.ObjectValue.CreateNotSupported (this, new ObjectPath (Name), Context.Adapter.GetDisplayTypeName (GetContext (options), Type), ex.Message, Flags);
 			} catch (EvaluatorException ex) {
-				return DC.ObjectValue.CreateError (this, new ObjectPath (Name), "", ex.Message, Flags);
+				return DC.ObjectValue.CreateError (this, new ObjectPath (Name), Context.Adapter.GetDisplayTypeName (GetContext (options), Type), ex.Message, Flags);
 			} catch (Exception ex) {
 				Context.WriteDebuggerError (ex);
 				return DC.ObjectValue.CreateUnknown (Name);


### PR DESCRIPTION
Problem is that .NET Framework assemblies don't have debug informations on iOS Devices when AOTed this causes `AbsentInformationException` to be thrown.
So change in ValueReference is to add TypeName so call stack is printed with types
Changes in rest of files is direct fix for this bug, problem was that one of methods in callstack had hoisted value, causing "GetThis" request, which caused exception and whole callstack went blank after that exception was thrown, so now we swallow this exception, since value is Absent anyway...