### PR TITLE
Fixed 551125 - [Feedback] Xamarin iOS debugger "unable to evaluate" simple expression

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -1648,9 +1648,13 @@ namespace Mono.Debugging.Soft
 
 		public override bool IsPrimitiveType (object type)
 		{
-			var tm = type as TypeMirror;
-
-			return tm != null && tm.IsPrimitive;
+			if (!(type is TypeMirror tm))
+				return false;
+			if (tm.IsPrimitive)
+				return true;
+			if (tm.IsValueType && tm.Namespace == "System" && (tm.Name == "nfloat" || tm.Name == "nint"))
+				return true;
+			return false;
 		}
 
 		public override bool IsClass (EvaluationContext ctx, object type)
@@ -1667,7 +1671,15 @@ namespace Mono.Debugging.Soft
 
 		public override bool IsPrimitive (EvaluationContext ctx, object val)
 		{
-			return val is PrimitiveValue || val is StringMirror || ((val is StructMirror) && ((StructMirror)val).Type.IsPrimitive) || val is PointerValue;
+			if (val is PrimitiveValue || val is StringMirror || val is PointerValue)
+				return true;
+			if (!(val is StructMirror sm))
+				return false;
+			if (sm.Type.IsPrimitive)
+				return true;
+			if (sm.Type.Namespace == "System" && (sm.Type.Name == "nfloat" || sm.Type.Name == "nint"))
+				return true;
+			return false;
 		}
 
 		public override bool IsPointer (EvaluationContext ctx, object val)

--- a/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/NRefactoryExpressionEvaluatorVisitor.cs
@@ -602,7 +602,12 @@ namespace Mono.Debugging.Evaluation
 
 			if (assignmentExpression.Operator == AssignmentOperatorType.Assign) {
 				var right = assignmentExpression.Right.AcceptVisitor<ValueReference> (this);
-				left.Value = right.Value;
+				if (left is UserVariableReference) {
+					left.Value = right.Value;
+				} else {
+					var castedValue = ctx.Adapter.TryCast (ctx, right.Value, left.Type);
+					left.Value = castedValue;
+				}
 			} else {
 				BinaryOperatorType op;
 
@@ -1113,6 +1118,10 @@ namespace Mono.Debugging.Evaluation
 			case UnaryOperatorType.Minus:
 				if (val is decimal) {
 					val = -(decimal)val;
+				} else if (val is double) {
+					val = -(double)val;
+				} else if (val is float) {
+					val = -(float)val;
 				} else {
 					num = -GetInteger (val);
 					val = Convert.ChangeType (num, val.GetType ());
@@ -1125,23 +1134,55 @@ namespace Mono.Debugging.Evaluation
 				val = !(bool) val;
 				break;
 			case UnaryOperatorType.PostDecrement:
-				num = GetInteger (val) - 1;
-				newVal = Convert.ChangeType (num, val.GetType ());
+				if (val is decimal) {
+					newVal = ((decimal)val) - 1;
+				} else if (val is double) {
+					newVal = ((double)val) - 1;
+				} else if (val is float) {
+					newVal = ((float)val) - 1;
+				} else {
+					num = GetInteger (val) - 1;
+					newVal = Convert.ChangeType (num, val.GetType ());
+				}
 				vref.Value = ctx.Adapter.CreateValue (ctx, newVal);
 				break;
 			case UnaryOperatorType.Decrement:
-				num = GetInteger (val) - 1;
-				val = Convert.ChangeType (num, val.GetType ());
+				if (val is decimal) {
+					val = ((decimal)val) - 1;
+				} else if (val is double) {
+					val = ((double)val) - 1;
+				} else if (val is float) {
+					val = ((float)val) - 1;
+				} else {
+					num = GetInteger (val) - 1;
+					val = Convert.ChangeType (num, val.GetType ());
+				}
 				vref.Value = ctx.Adapter.CreateValue (ctx, val);
 				break;
 			case UnaryOperatorType.PostIncrement:
-				num = GetInteger (val) + 1;
-				newVal = Convert.ChangeType (num, val.GetType ());
+				if (val is decimal) {
+					newVal = ((decimal)val) + 1;
+				} else if (val is double) {
+					newVal = ((double)val) + 1;
+				} else if (val is float) {
+					newVal = ((float)val) + 1;
+				} else {
+					num = GetInteger (val) + 1;
+					newVal = Convert.ChangeType (num, val.GetType ());
+				}
 				vref.Value = ctx.Adapter.CreateValue (ctx, newVal);
 				break;
 			case UnaryOperatorType.Increment:
-				num = GetInteger (val) + 1;
-				val = Convert.ChangeType (num, val.GetType ());
+				if (val is decimal) {
+					val = ((decimal)val) + 1;
+				} else if (val is double) {
+					val = ((double)val) + 1;
+				} else if (val is float) {
+					val = ((float)val) + 1;
+				} else {
+					num = GetInteger (val) + 1;
+					val = Convert.ChangeType (num, val.GetType ());
+				}
 				vref.Value = ctx.Adapter.CreateValue (ctx, val);
 				break;
 			case UnaryOperatorType.Plus:

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -1092,13 +1092,13 @@ namespace Mono.Debugging.Evaluation
 				return new EvaluationResult ("{" + ename + tn + "}");
 			}
 
+			object type = GetValueType (ctx, obj);
+			string typeName = GetTypeName (ctx, type);
 			if (IsEnum (ctx, obj)) {
-				object type = GetValueType (ctx, obj);
 				object longType = GetType (ctx, "System.Int64");
 				object c = Cast (ctx, obj, longType);
 				long val = (long) TargetObjectToObject (ctx, c);
 				long rest = val;
-				string typeName = GetTypeName (ctx, type);
 				string composed = string.Empty;
 				string composedDisplay = string.Empty;
 
@@ -1123,12 +1123,16 @@ namespace Mono.Debugging.Evaluation
 				return new EvaluationResult (val.ToString ());
 			}
 
-			if (GetValueTypeName (ctx, obj) == "System.Decimal") {
+			if (typeName == "System.Decimal") {
 				string res = CallToString (ctx, obj);
 				// This returns the decimal formatted using the current culture. It has to be converted to invariant culture.
 				decimal dec = decimal.Parse (res);
 				res = dec.ToString (System.Globalization.CultureInfo.InvariantCulture);
 				return new EvaluationResult (res);
+			}
+
+			if (typeName == "System.nfloat" || typeName == "System.nint") {
+				return TargetObjectToObject (ctx, GetMembersSorted (ctx, null, type, obj, BindingFlags.Instance | BindingFlags.NonPublic).Single ().Value);
 			}
 
 			if (IsClassInstance (ctx, obj)) {

--- a/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/EvaluationTests.cs
@@ -1531,6 +1531,9 @@ namespace Mono.Debugging.Tests
 			val = Eval ("(ulong)1 + (long)2");
 			Assert.AreEqual ("3", val.Value);
 			Assert.AreEqual ("ulong", val.TypeName);
+
+			val = Eval ("-(2.3)");
+			Assert.AreEqual ("-2.3", val.Value);
 		}
 
 		[Test]
@@ -1670,6 +1673,10 @@ namespace Mono.Debugging.Tests
 		{
 			AssertAssignment ("n = 6", "n", "6", "int");
 			AssertAssignment ("n = 32", "n", "32", "int");
+
+			AssertAssignment ("d = 33", "d", "33", "double");
+			AssertAssignment ("d = 34.0", "d", "34", "double");
+			AssertAssignment ("d = 35.0f", "d", "35", "double");
 
 			AssertAssignment ("someString = \"test\"", "someString", "\"test\"", "string");
 			AssertAssignment ("someString = \"hi\"", "someString", "\"hi\"", "string");

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -223,6 +223,7 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 		{
 			int intZero = 0, intOne = 1;
 			int n = 32;
+			double d;
 			decimal dec = 123.456m;
 			var stringList = new List<string> ();
 			stringList.Add ("aaa");


### PR DESCRIPTION
There were actually 2 bugs that needed fixing
1) In VisitUnaryOperatorExpression decimal values were lost(only whole part of number was negative)
2) None of arithmetic operations on System.nfloat and System.nint worked, because it considered it as struct and not double/float/int/long, this is fixed in ObjectValueAdapter

I also found that `double a = 23` didn't work because there was no cast from `int` to `double`, this is fixed in VisitAssignmentExpression
Also added unit tests