### PR TITLE
[Debugger] Make catchpoint properties settable

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/Catchpoint.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Catchpoint.cs
@@ -68,10 +68,12 @@ namespace Mono.Debugging.Client
 		
 		public string ExceptionName {
 			get { return exceptionName; }
+			set { exceptionName = value; }
 		}
 
 		public bool IncludeSubclasses {
 			get { return includeSubclasses; }
+			set { includeSubclasses = value; }
 		}
 		
 		public override void CopyFrom (BreakEvent ev)


### PR DESCRIPTION
To allow editing of catchpoints after they have been created they need to be
settable