### PR TITLE
Make unit tests relocatable

### DIFF
--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/MonoDevelop.Debugger.Tests.TestApp.csproj
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/MonoDevelop.Debugger.Tests.TestApp.csproj
@@ -63,7 +63,7 @@
       <HintPath>..\MonoDevelop.Debugger.Tests.NonUserCodeTestLib\bin\Debug\MonoDevelop.Debugger.Tests.NonUserCodeTestLib.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/MonoDevelop.Debugger.Tests.TestApp.csproj
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/MonoDevelop.Debugger.Tests.TestApp.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
-    <OutputPath>..\..\..\..\build\tests</OutputPath>
+    <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\build\tests</OutputPath>
+    <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
We need to run them outside of the MD source tree.