### PR TITLE
Fix locals for local functions

### DIFF
--- a/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
@@ -167,6 +167,60 @@ namespace Mono.Debugging.Tests
 		}
 
 		[Test]
+		public void LocalFunctionNoCaptureVariablesTest ()
+		{
+			InitializeTest ();
+			AddBreakpoint ("056bb4b5-1c7a-4e21-bd93-abd7389809d0");
+			StartTest ("LocalFunctionNoCaptureVariablesTest");
+			CheckPosition ("056bb4b5-1c7a-4e21-bd93-abd7389809d0");
+
+			var val = Eval ("a");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("17", val.Value);
+
+			var frame = Session.ActiveThread.Backtrace.GetFrame (0);
+			var locals = frame.GetAllLocals ();
+			Assert.AreEqual (3, locals.Length);
+
+			val = locals.Single (l => l.Name == "a");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("17", val.Value);
+
+			val = locals.Single (l => l.Name == "b");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("23", val.Value);
+
+			val = locals.Single (l => l.Name == "c");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("31", val.Value);
+		}
+
+		[Test]
+		public void LocalFunctionCaptureDelegateVariablesTest ()
+		{
+			InitializeTest ();
+			AddBreakpoint ("94100486-d7c4-4239-9d87-ad61287117d5");
+			StartTest ("LocalFunctionCaptureDelegateVariablesTest");
+			CheckPosition ("94100486-d7c4-4239-9d87-ad61287117d5");
+
+			var val = Eval ("a");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("5", val.Value);
+
+			var frame = Session.ActiveThread.Backtrace.GetFrame (0);
+			var locals = frame.GetAllLocals ();
+			Assert.AreEqual (2, locals.Length);
+
+			val = locals.Single (l => l.Name == "a");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("5", val.Value);
+
+			val = locals.Single (l => l.Name == "i");
+			Assert.AreEqual ("int", val.TypeName);
+			Assert.AreEqual ("7", val.Value);
+		}
+
+		[Test]
 		public void YieldMethodTest ()
 		{
 			InitializeTest ();

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/AdvancedEvaluation.cs
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/AdvancedEvaluation.cs
@@ -52,15 +52,42 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			}
 		}
 
-		public void LocalFunctionVariablesTest ()
+		public static void LocalFunctionVariablesTest()
 		{
 			var a = 23;
-			int localFunction (int b, string c)
+			localFunction(24, "hi");
+
+			int localFunction(int b, string c)
 			{
 				var d = 25;
 				return a + b + d;/*07a0e6ef-e1d2-4f11-ab67-78e6ae5ea3bb*/
 			}
-			localFunction (24, "hi");
+		}
+
+		public static void LocalFunctionNoCaptureVariablesTest()
+		{
+			localFunction(17, 23, 31);
+
+			int localFunction(int a, int b, int c)
+			{
+				return a + b + c;/*056bb4b5-1c7a-4e21-bd93-abd7389809d0*/
+			}
+		}
+
+		public static void LocalFunctionCaptureDelegateVariablesTest()
+		{
+			var add = LocalFunctionCaptureDelegateVariablesTest_CreateAdder(7);
+			add(5);
+		}
+
+		static Func<int, int> LocalFunctionCaptureDelegateVariablesTest_CreateAdder(int i)
+		{
+			return localFunction;
+
+			int localFunction(int a)
+			{
+				return a + i;/*94100486-d7c4-4239-9d87-ad61287117d5*/
+			}
 		}
 
 		public void YieldMethodTest ()


### PR DESCRIPTION
The existing fix (#170) only handled the case where a local function captures locals from the parent scope on a ref struct. This fixes the case where the function does not capture and the case where it creates a class closure.