### PR TITLE
Explicit Nuget.config. Update readme.md

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,5 @@
+<configuration>
+    <config>
+        <add key="repositoryPath" value="packages" />
+    </config>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,5 @@ Dependencies
 
 The libraries in this repository have external dependencies, specifically:
 
-* cecil (git://github.com/mono/cecil.git)
-* nrefactory (git://github.com/icsharpcode/NRefactory.git)
-
-Those libraries must be cloned side by side with debugger-libs.
+* cecil (https://www.nuget.org/packages/Mono.Cecil/).
+* nrefactory (git://github.com/icsharpcode/NRefactory.git). Must be cloned side by side with debugger-libs.


### PR DESCRIPTION
* Added explicit nuget.config
* Remove from readme that cecil must be cloned to same dir as debugger-libs

Without nuget.config msbuild on my system ArchLinux `Linux 4.17.6-1-ARCH` don't install external packages. Readme was changed because Cecil was added as package to .csproj files