### PR TITLE
Fixed steping on static constructor and methods they call

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1418,7 +1418,7 @@ namespace Mono.Debugging.Soft
 					var req = vm.CreateStepRequest (current_thread);
 					req.Depth = depth;
 					req.Size = size;
-					req.Filter = StepFilter.StaticCtor | StepFilter.DebuggerHidden | StepFilter.DebuggerStepThrough;
+					req.Filter = ShouldFilterStaticCtor() | StepFilter.DebuggerHidden | StepFilter.DebuggerStepThrough;
 					if (Options.ProjectAssembliesOnly)
 						req.Filter |= StepFilter.DebuggerNonUserCode;
 					if (assemblyFilters != null && assemblyFilters.Count > 0)
@@ -1452,6 +1452,13 @@ namespace Mono.Debugging.Soft
 					DebuggerLoggingService.LogError ("Step request failed", ex);
 				}
 			});
+		}
+
+		private StepFilter ShouldFilterStaticCtor()
+		{
+			var frames = current_thread.GetFrames();
+			return (frames.Any(f => f.Method.Name == ".cctor" && f.Method.IsSpecialName && f.Method.IsStatic))
+				? StepFilter.None : StepFilter.StaticCtor;
 		}
 
 		void EventHandler ()


### PR DESCRIPTION
We have a filter on stepping to avoid showing tens of static
constructors when classes are being used. This is ok, but it also
filters out normal steping on a static constructor the dev may want to
see. I added a condition where if there is an actual .cctor in the
trace, then the filtering will not happen. This works ok for both
scenarios.