### PR TITLE
SoftDebuggerAdaptor: support CoreFX Nullable implementation

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -731,7 +731,7 @@ namespace Mono.Debugging.Soft
 
 		public override bool NullableHasValue (EvaluationContext ctx, object type, object obj)
 		{
-			var hasValue = GetMember (ctx, type, obj, "has_value");
+			var hasValue = GetMember (ctx, type, obj, "hasValue") ?? GetMember (ctx, type, obj, "has_value");
 
 			return (bool) hasValue.ObjectValue;
 		}


### PR DESCRIPTION
When Mono switched to the Nullable implementation from CoreFX with https://github.com/mono/mono/commit/275d7bfc2ca17aa03a9daeb32493ee0ef9078037
some tests in VSMac broke because the SoftDebuggerAdaptor is checking for the old field name in the type.

Updated the adaptor to support both the CoreFX and the old Mono field name.

https://github.com/mono/mono/issues/10794