### PR TITLE
[Debugger] Record time it took between steps.

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -507,7 +507,8 @@ namespace Mono.Debugger.Soft
 			GET_ID = 5,
 			/* Ditto */
 			GET_TID = 6,
-			SET_IP = 7
+			SET_IP = 7,
+			GET_ELAPSED_TIME = 8
 		}
 
 		enum CmdEventRequest {
@@ -2041,7 +2042,9 @@ namespace Mono.Debugger.Soft
 		internal string Thread_GetName (long id) {
 			return SendReceive (CommandSet.THREAD, (int)CmdThread.GET_NAME, new PacketWriter ().WriteId (id)).ReadString ();
 		}
-
+		internal long Thread_GetElapsedTime (long id) {
+			return SendReceive (CommandSet.THREAD, (int)CmdThread.GET_ELAPSED_TIME, new PacketWriter ().WriteId (id)).ReadLong ();
+		}
 		internal void Thread_GetFrameInfo (long id, int start_frame, int length, Action<FrameInfo[]> resultCallaback) {
 			Send (CommandSet.THREAD, (int)CmdThread.GET_FRAME_INFO, new PacketWriter ().WriteId (id).WriteInt (start_frame).WriteInt (length), (res) => {
 				int count = res.ReadInt ();

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
@@ -30,11 +30,18 @@ namespace Mono.Debugger.Soft
 			return frames;
 		}
 
+		public long ElapsedTime () {
+			long elapsedTime = GetElapsedTime ();
+			return elapsedTime;
+		}
+
 		internal void InvalidateFrames () {
 			cacheInvalid = true;
 			threadStateInvalid = true;
 		}
-
+		internal long GetElapsedTime () {
+			return vm.conn.Thread_GetElapsedTime (id);
+		}
 		internal void FetchFrames (bool mustFetch = false) {
 			lock (fetchingLocker) {
 				if (fetching || !cacheInvalid)

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -754,10 +754,20 @@ namespace Mono.Debugging.Soft
 		{
 			return GetThreadBacktrace (GetThread (threadId));
 		}
-		
+
+		protected override long OnGetElapsedTime (long processId, long threadId)
+		{
+			return GetElapsedTime (GetThread (threadId));
+		}
+
 		Backtrace GetThreadBacktrace (ThreadMirror thread)
 		{
 			return new Backtrace (new SoftDebuggerBacktrace (this, thread));
+		}
+
+		long GetElapsedTime (ThreadMirror thread)
+		{
+			return thread.ElapsedTime ();
 		}
 
 		string GetThreadName (ThreadMirror t)
@@ -1409,9 +1419,10 @@ namespace Mono.Debugging.Soft
 		{
 			Step (StepDepth.Over, StepSize.Line);
 		}
-		
+
 		void Step (StepDepth depth, StepSize size)
 		{
+
 			ThreadPool.QueueUserWorkItem (delegate {
 				try {
 					Adaptor.CancelAsyncOperations (); // This call can block, so it has to run in background thread to avoid keeping the main session lock

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -1035,7 +1035,15 @@ namespace Mono.Debugging.Client
 				return bt;
 			}
 		}
-		
+
+		internal long GetElapsedTime (long processId, long threadId)
+		{
+			lock (slock) {
+				long elapsedTime = OnGetElapsedTime (processId, threadId);
+				return elapsedTime;
+			}
+		}
+
 		void ForceStop ()
 		{
 			TargetEventArgs args = new TargetEventArgs (TargetEventType.TargetStopped);
@@ -1596,7 +1604,21 @@ namespace Mono.Debugging.Client
 		/// This method can only be called when the debuggee is stopped by the debugger
 		/// </remarks>
 		protected abstract Backtrace OnGetThreadBacktrace (long processId, long threadId);
-		
+
+		/// <summary>
+		/// Called to get the elapsedTime of last step of a thread
+		/// </summary>
+		/// <param name='processId'>
+		/// Process identifier.
+		/// </param>
+		/// <param name='threadId'>
+		/// Thread identifier.
+		/// </param>
+		/// <remarks>
+		/// This method can only be called when the debuggee is stopped by the debugger
+		/// </remarks>
+		protected abstract long OnGetElapsedTime (long processId, long threadId);
+
 		/// <summary>
 		/// Called to gets the disassembly of a source code file
 		/// </summary>

--- a/Mono.Debugging/Mono.Debugging.Client/ThreadInfo.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ThreadInfo.cs
@@ -80,7 +80,14 @@ namespace Mono.Debugging.Client
 				return backtrace;
 			}
 		}
-		
+
+		public long ElapsedTime {
+			get {
+				long elapsedTime = session.GetElapsedTime (processId, id);
+				return elapsedTime;
+			}
+		}
+
 		public void SetActive ()
 		{
 			session.ActiveThread = this;


### PR DESCRIPTION
I implemented a new message to avoid breaking the protocol. I used the MonoStopwatch to count the time between the steps, it was already used in the debugger-agent.
Fixes #8460