### PR TITLE
[Debugger] Record time it took between steps.

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -1617,7 +1617,10 @@ namespace Mono.Debugging.Client
 		/// <remarks>
 		/// This method can only be called when the debuggee is stopped by the debugger
 		/// </remarks>
-		protected abstract long OnGetElapsedTime (long processId, long threadId);
+		protected virtual long OnGetElapsedTime (long processId, long threadId)
+		{
+			return 0;
+		}
 
 		/// <summary>
 		/// Called to gets the disassembly of a source code file


### PR DESCRIPTION
Changing the method OnGetElapsedTime from abstract to virtual.
Fixes #8460