### PR TITLE
Fixes evaluation of code that spawns new threads

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -2734,7 +2734,7 @@ namespace Mono.Debugging.Soft
 
 	class MethodCall: AsyncOperation
 	{
-		readonly InvokeOptions options = InvokeOptions.DisableBreakpoints | InvokeOptions.SingleThreaded;
+		readonly InvokeOptions options = InvokeOptions.DisableBreakpoints;
 
 		readonly ManualResetEvent shutdownEvent = new ManualResetEvent (false);
 		readonly SoftEvaluationContext ctx;


### PR DESCRIPTION
Code that spawned a new thread would show 'Timed out' message in
the debugger due to the use of `InvokeOptions.SingleThread`.

Fixes https://github.com/mono/mono/issues/8429

Credit to @thaystg for finding the fix.