### PR TITLE
Fixes couple of crashes in the debugger

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -297,7 +297,11 @@ namespace Mono.Debugging.Client
 									}
 								}
 								lock (slock) {
-									actionToExecute ();
+									try {
+										actionToExecute ();
+									} catch (Exception ex) {
+										HandleException (ex);
+									}
 								}
 							}
 						});


### PR DESCRIPTION
Fixes VSTS #801713

```
[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Debugger.VsCodeDebugProtocol.VSCodeDebuggerSession.UpdateBreakpoints () [0x00191] in /Users/vsts/agent/2.147.1/work/1/s/monodevelop/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs:388
  at MonoDevelop.Debugger.VsCodeDebugProtocol.VSCodeDebuggerSession.OnUpdateBreakEvent (Mono.Debugging.Client.BreakEventInfo eventInfo) [0x0003d] in /Users/vsts/agent/2.147.1/work/1/s/monodevelop/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs:442
  at Mono.Debugging.Client.DebuggerSession.UpdateBreakEvent (Mono.Debugging.Client.BreakEvent be) [0x00021] in /Users/vsts/agent/2.147.1/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs:687
  at Mono.Debugging.Client.DebuggerSession+<>c__DisplayClass116_0.<OnBreakpointModified>b__0 () [0x0000d] in /Users/vsts/agent/2.147.1/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs:722
  at Mono.Debugging.Client.DebuggerSession.<Dispatch>b__92_0 (System.Object
  <p0>) [0x00054] in
  /Users/vsts/agent/2.147.1/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs:300
```

Also fixes Unity debugging crash

```
MonoDevelop.Debugger.AD7.dll!MonoDevelop.Debugger.AD7.AD7StackFrame.GetValue+ffffffff
           Mono.Debugging.dll!Mono.Debugging.Client.ObjectValue.Refresh+9
           MonoDevelop.Debugger.dll!MonoDevelop.Debugger.PreviewVisualizers.GenericPreviewVisualizer.GetVisualizerWidget+29

Stack 2:
           MonoDevelop.Debugger.AD7.dll!MonoDevelop.Debugger.AD7.AD7DebuggerSession.OnUpdateBreakEvent+ffffffff
           Mono.Debugging.dll!Mono.Debugging.Client.DebuggerSession.UpdateBreakEvent+21
           c1e5b1e0-c6e2-44e5-8a49-f9dbf064e47e!60006a3+d (UNKNOWN MVID)
           Mono.Debugging.dll!Mono.Debugging.Client.DebuggerSession.<Dispatch>b__92_0+21

Stack 3:
           MonoDevelop.Debugger.AD7.dll!MonoDevelop.Debugger.AD7.AD7Backtrace.GetExpressionValues+ffffffff
           Mono.Debugging.dll!Mono.Debugging.Client.StackFrame.GetExpressionValue+20
           Mono.Debugging.dll!Mono.Debugging.Client.StackFrame.GetExpressionValue+20
```