### PR TITLE
[Mono.Debugging.Soft] support building on Windows

### DIFF
--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -75,7 +75,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Posix" />
+    <Reference        Condition=" '$(OS)' != 'Windows_NT' " Include="Mono.Posix" />
+    <PackageReference Condition=" '$(OS)' == 'Windows_NT' " Include="Mono.Posix-4.5" Version="4.5.0" />
   </ItemGroup>
   <Import Project="..\Mono.Debugging.settings" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/bf58a880e5da244462fbae401f06153569836c96

In xamarin-android, we have started using this library for some of our
integration tests.

This causes our Windows build to fail with:

    SoftDebuggerSession.cs(2606,30): error CS0234: The type or namespace name 'Unix' does not exist in the namespace 'Mono' (are you missing an assembly reference?)
    [C:\src\xamarin-android\external\debugger-libs\Mono.Debugging.Soft\Mono.Debugging.Soft.csproj]

For now, we just need these libraries to *build* on Windows.

So if we conditionally use a NuGet package for Mono.Posix:

    <Reference        Condition=" '$(OS)' != 'Windows_NT' " Include="Mono.Posix" />
    <PackageReference Condition=" '$(OS)' == 'Windows_NT' " Include="Mono.Posix-4.5" Version="4.5.0" />

I'm able to build on Windows, and all is well.