### PR TITLE
[Mono.Debugging.Soft] Added VariableValueReference.GetValue

### DIFF
--- a/Mono.Debugging.Soft/VariableValueReference.cs
+++ b/Mono.Debugging.Soft/VariableValueReference.cs
@@ -89,6 +89,19 @@ namespace Mono.Debugging.Soft
 			return ctx.Adapter.IsNull (ctx, value) ? null : value;
 		}
 
+		public override object GetValue (EvaluationContext ctx)
+		{
+			try {
+				value = ((SoftEvaluationContext) ctx).Frame.GetValue (variable);
+
+				return NormalizeValue (ctx, value);
+			} catch (AbsentInformationException ex) {
+				throw new EvaluatorException (ex, "Value not available");
+			} catch (ArgumentException ex) {
+				throw new EvaluatorException (ex.Message);
+			}
+		}
+
 		public override object Value {
 			get {
 				var ctx = (SoftEvaluationContext) Context;


### PR DESCRIPTION
This is needed for ObjectValue.Refresh() to work properly
and get the latest value (if it was changed) because otherwise
the base class (ValueReference) just returns .Value which may
already be cached.

Needed by https://github.com/xamarin/monodevelop/pull/657