### PR TITLE
SoftDebuggerAdaptor.GetValueType() can return System.Type (not always…

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -992,7 +992,18 @@ namespace Mono.Debugging.Soft
 		{
 			try {
 				var val = cx.Frame.GetThis ();
-				var type = (TypeMirror) GetValueType (cx, val);
+				var valueType = GetValueType (cx, val);
+				var type = valueType as TypeMirror;
+
+				if (type == null) {
+					var tt = valueType as Type;
+
+					if (tt == null)
+						return null;
+
+					type = (TypeMirror) ForceLoadType (cx, tt.FullName);
+				}
+
 				return GetHoistedThisReference (cx, type, val);
 			} catch (AbsentInformationException) {
 			}


### PR DESCRIPTION
… TypeMirror)

Properly handle this case when getting a hoisted @this reference

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/901162/