### PR TITLE
[Mono.Debugging] Improved source checksum logic for UNIX and DOS line…

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/SourceLocation.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/SourceLocation.cs
@@ -1,4 +1,7 @@
 using System;
+using System.IO;
+using System.Buffers;
+using System.Security.Cryptography;
 
 namespace Mono.Debugging.Client
 {
@@ -35,5 +38,124 @@ namespace Mono.Debugging.Client
 			return string.Format("[SourceLocation Method={0}, Filename={1}, Line={2}, Column={3}]", MethodName, FileName, Line, Column);
 		}
 
+		static void ComputeHashes (Stream stream, HashAlgorithm hash, HashAlgorithm dos, HashAlgorithm unix)
+		{
+			var unixBuffer = ArrayPool<byte>.Shared.Rent (4096 + 1);
+			var dosBuffer = ArrayPool<byte>.Shared.Rent (8192 + 1);
+			var buffer = ArrayPool<byte>.Shared.Rent (4096);
+			byte pc = 0;
+			int count;
+
+			try {
+				while ((count = stream.Read (buffer, 0, buffer.Length)) > 0) {
+					int unixIndex = 0, dosIndex = 0;
+
+					for (int i = 0; i < count; i++) {
+						var c = buffer[i];
+
+						if (c == (byte) '\r') {
+							if (pc == (byte) '\r')
+								unixBuffer[unixIndex++] = pc;
+							dosBuffer[dosIndex++] = c;
+						} else if (c == (byte) '\n') {
+							if (pc != (byte) '\r')
+								dosBuffer[dosIndex++] = (byte) '\r';
+							unixBuffer[unixIndex++] = c;
+							dosBuffer[dosIndex++] = c;
+						} else {
+							if (pc == (byte) '\r')
+								unixBuffer[unixIndex++] = pc;
+							unixBuffer[unixIndex++] = c;
+							dosBuffer[dosIndex++] = c;
+						}
+
+						pc = c;
+					}
+
+					hash.TransformBlock (buffer, 0, count, outputBuffer: null, outputOffset: 0);
+					dos.TransformBlock (dosBuffer, 0, dosIndex, outputBuffer: null, outputOffset: 0);
+					unix.TransformBlock (unixBuffer, 0, unixIndex, outputBuffer: null, outputOffset: 0);
+				}
+
+				hash.TransformFinalBlock (buffer, 0, 0);
+				dos.TransformFinalBlock (buffer, 0, 0);
+				unix.TransformFinalBlock (buffer, 0, 0);
+			} finally {
+				ArrayPool<byte>.Shared.Return (unixBuffer);
+				ArrayPool<byte>.Shared.Return (dosBuffer);
+				ArrayPool<byte>.Shared.Return (buffer);
+			}
+		}
+
+		static bool ChecksumsEqual (byte[] calculated, byte[] checksum, int skip = 0)
+		{
+			if (skip > 0) {
+				if (calculated.Length < checksum.Length - skip)
+					return false;
+			} else {
+				if (calculated.Length != checksum.Length)
+					return false;
+			}
+
+			for (int i = 0, csi = skip; csi < checksum.Length; i++, csi++) {
+				if (calculated[i] != checksum[csi])
+					return false;
+			}
+
+			return true;
+		}
+
+		static bool CheckHash (Stream stream, string algorithm, byte[] checksum)
+		{
+			using (var hash = HashAlgorithm.Create (algorithm)) {
+				int size = hash.HashSize / 8;
+
+				using (var dos = HashAlgorithm.Create (algorithm)) {
+					using (var unix = HashAlgorithm.Create (algorithm)) {
+						stream.Position = 0;
+
+						ComputeHashes (stream, hash, dos, unix);
+
+						if (checksum [0] == size && checksum.Length < size) {
+							return ChecksumsEqual (hash.Hash, checksum, 1) ||
+								ChecksumsEqual (unix.Hash, checksum, 1) ||
+								ChecksumsEqual (dos.Hash, checksum, 1);
+						}
+
+						return ChecksumsEqual (hash.Hash, checksum) ||
+							ChecksumsEqual (unix.Hash, checksum) ||
+							ChecksumsEqual (dos.Hash, checksum);
+					}
+				}
+			}
+		}
+
+		public static bool CheckFileHash (string path, byte[] checksum)
+		{
+			if (checksum == null || checksum.Length == 0 || !File.Exists (path))
+				return false;
+
+			using (var stream = File.OpenRead (path)) {
+				if (checksum.Length == 16) {
+					// Note: Roslyn SHA1 hashes are 16 bytes and start w/ 20
+					if (checksum[0] == 20 && CheckHash (stream, "SHA1", checksum))
+						return true;
+
+					// Note: Roslyn SHA256 hashes are 16 bytes and start w/ 32
+					if (checksum[0] == 32 && CheckHash (stream, "SHA256", checksum))
+						return true;
+
+					return CheckHash (stream, "MD5", checksum);
+				}
+
+				if (checksum.Length == 20)
+					return CheckHash (stream, "SHA1", checksum);
+
+				if (checksum.Length == 32)
+					return CheckHash (stream, "SHA256", checksum);
+			}
+
+			return false;
+		}
 	}
 }

--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -11,6 +11,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>mono.debugging.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>Mono.Debugging</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -45,6 +46,20 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Buffers">
+      <HintPath>..\..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\nrefactory\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">
+      <Project>{3B2A5653-EC97-4001-BB9B-D90F1AF2C371}</Project>
+      <Name>ICSharpCode.NRefactory</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\nrefactory\ICSharpCode.NRefactory.CSharp\ICSharpCode.NRefactory.CSharp.csproj">
+      <Project>{53DCA265-3C3C-42F9-B647-F72BA678122B}</Project>
+      <Name>ICSharpCode.NRefactory.CSharp</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mono.Debugging.Client\IExpressionEvaluator.cs" />
@@ -128,17 +143,9 @@
     <Compile Include="Mono.Debugging.Evaluation\EvaluationStatistics.cs" />
     <Compile Include="Mono.Debugging.Evaluation\LambdaBodyOutputVisitor.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="..\Mono.Debugging.settings" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup />
-  <ItemGroup>
-    <ProjectReference Include="..\..\nrefactory\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">
-      <Project>{3B2A5653-EC97-4001-BB9B-D90F1AF2C371}</Project>
-      <Name>ICSharpCode.NRefactory</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\nrefactory\ICSharpCode.NRefactory.CSharp\ICSharpCode.NRefactory.CSharp.csproj">
-      <Project>{53DCA265-3C3C-42F9-B647-F72BA678122B}</Project>
-      <Name>ICSharpCode.NRefactory.CSharp</Name>
-    </ProjectReference>
-  </ItemGroup>
 </Project>

--- a/Mono.Debugging/packages.config
+++ b/Mono.Debugging/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
+</packages>

--- a/UnitTests/Mono.Debugging.Tests/Shared/SourceLocationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/SourceLocationTests.cs
@@ -1,0 +1,99 @@
+//
+// SourceLocationTests.cs
+//
+// Author:
+//       Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Security.Cryptography;
+
+using Mono.Debugging.Client;
+
+using NUnit.Framework;
+
+namespace Mono.Debugging.Tests
+{
+	[TestFixture]
+	public class SourceLocationTests
+	{
+		static void TestCheckFileHash (string algorithm, string text, string mode)
+		{
+			var buffer = Encoding.ASCII.GetBytes (text);
+
+			using (var hash = HashAlgorithm.Create (algorithm)) {
+				var checksum = hash.ComputeHash (buffer);
+				string tmp;
+
+				tmp = Path.GetTempFileName ();
+				File.WriteAllBytes (tmp, buffer);
+
+				Assert.IsTrue (SourceLocation.CheckFileHash (tmp, checksum), "CheckFileHash {0} ({1})", algorithm, mode);
+
+				if (checksum.Length > 16) {
+					var roslyn = new byte[16];
+
+					roslyn[0] = (byte) checksum.Length;
+					for (int i = 1; i < 16; i++)
+						roslyn[i] = checksum[i - 1];
+
+					Assert.IsTrue (SourceLocation.CheckFileHash (tmp, checksum), "CheckFileHash Roslyn {0} ({1})", algorithm, mode);
+				}
+			}
+		}
+
+		static void TestCheckFileHash (string algorithm)
+		{
+			string text = "This is line 1.\nThis is line 2.\r\nThis is line 3.\r\nThis is line 4.\nThis is line 5.\n";
+
+			TestCheckFileHash (algorithm, text, "MIXED");
+
+			text = text.Replace ("\r\n", "\n");
+
+			TestCheckFileHash (algorithm, text, "UNIX");
+
+			text = text.Replace ("\n", "\r\n");
+
+			TestCheckFileHash (algorithm, text, "DOS");
+		}
+
+		[Test]
+		public void TestCheckFileHashSha1 ()
+		{
+			TestCheckFileHash ("SHA1");
+		}
+
+		[Test]
+		public void TestCheckFileHashSha256 ()
+		{
+			TestCheckFileHash ("SHA256");
+		}
+
+		[Test]
+		public void TestCheckFileHashMd5 ()
+		{
+			TestCheckFileHash ("MD5");
+		}
+	}
+}


### PR DESCRIPTION
… endings

Since it is possible that the assemblies being debugged could have
been compiled on a different system (potentially with different line
endings), compute hashes for the source code in 3 formats:

1. The source code file with line endings as-is
2. The source code file with DOS line endings
3. The source code file with UNIX line endings

Note: sometimes source code may have mixed line endings, so it is
important to calculate the source code as-is and not just
canonicalized UNIX and DOS line endings.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/642329
Fixes issue #5260