### PR TITLE
Added EvaluationContext to AsyncOperation

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -2748,7 +2748,6 @@ namespace Mono.Debugging.Soft
 		readonly InvokeOptions options = InvokeOptions.DisableBreakpoints;
 
 		readonly ManualResetEvent shutdownEvent = new ManualResetEvent (false);
-		readonly SoftEvaluationContext ctx;
 		readonly MethodMirror function;
 		readonly Value[] args;
 		readonly object obj;
@@ -2756,9 +2755,8 @@ namespace Mono.Debugging.Soft
 		Exception exception;
 		InvokeResult result;
 		
-		public MethodCall (SoftEvaluationContext ctx, MethodMirror function, object obj, Value[] args, bool enableOutArgs)
+		public MethodCall (SoftEvaluationContext ctx, MethodMirror function, object obj, Value[] args, bool enableOutArgs) : base (ctx)
 		{
-			this.ctx = ctx;
 			this.function = function;
 			this.obj = obj;
 			this.args = args;
@@ -2778,6 +2776,8 @@ namespace Mono.Debugging.Soft
 
 		public override void Invoke ()
 		{
+			var ctx = (SoftEvaluationContext) EvaluationContext;
+
 			try {
 				if (obj is ObjectMirror)
 					handle = ((ObjectMirror)obj).BeginInvokeMethod (ctx.Thread, function, args, options, null, null);
@@ -2818,6 +2818,8 @@ namespace Mono.Debugging.Soft
 		
 		void EndInvoke ()
 		{
+			var ctx = (SoftEvaluationContext) EvaluationContext;
+
 			try {
 				if (obj is ObjectMirror)
 					result = ((ObjectMirror)obj).EndInvokeMethodWithResult (handle);

--- a/Mono.Debugging.Win32/CorDebuggerSession.cs
+++ b/Mono.Debugging.Win32/CorDebuggerSession.cs
@@ -1417,7 +1417,7 @@ namespace Mono.Debugging.Win32
 				arguments.CopyTo (args, 1);
 			}
 
-			CorMethodCall mc = new CorMethodCall ();
+			CorMethodCall mc = new CorMethodCall (ctx);
 			CorValue exception = null;
 			CorEval eval = ctx.Eval;
 

--- a/Mono.Debugging.Win32/CorMethodCall.cs
+++ b/Mono.Debugging.Win32/CorMethodCall.cs
@@ -19,6 +19,10 @@ namespace Mono.Debugging.Win32
 			get { return OnGetDescription (); }
 		}
 
+		public CorMethodCall (CorEvaluationContext ctx) : base (ctx)
+		{
+		}
+
 		public override void Invoke ( )
 		{
 			OnInvoke ();

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -1731,6 +1731,8 @@ namespace Mono.Debugging.Client
 		public bool IsBusy { get; internal set; }
 		
 		public string Description { get; internal set; }
+
+		public EvaluationContext EvaluationContext { get; internal set; }
 	}
 	
 	public interface IConnectionDialog : IDisposable


### PR DESCRIPTION
SoftDebugger's MethodCall async op already had it (Cor did not),
but we need this to report telemetry on what evaluation options
were enabled for the particular async op that is busy.

Partial "fix" to hopefully allow us to get more info about why/when
this is happening for our users.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/802365/