### PR TITLE
Switched packages.config to PackageReference

### DIFF
--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -47,9 +47,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="mscorlib" />
-    <Reference Include="System.Buffers">
-      <HintPath>..\..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\nrefactory\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">
@@ -144,7 +141,7 @@
     <Compile Include="Mono.Debugging.Evaluation\LambdaBodyOutputVisitor.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
   <Import Project="..\Mono.Debugging.settings" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Mono.Debugging/packages.config
+++ b/Mono.Debugging/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
A packages.config was recently added to include System.Buffers. packages.config should not be used anymore, specially for new projects. I'm switching this to PackageReference, and also removing the HintPath which is breaking (and may break) external consumers.