### PR TITLE
[Mono.Debugging.Evaluation] Set the expression as the ObjectValue.Name

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
@@ -84,7 +84,6 @@ namespace Mono.Debugging.Client
 			val.flags = flags | ObjectValueFlags.Object;
 			val.displayValue = value.DisplayValue;
 			val.value = value.Value;
-			val.path = path;
 
 			if (children != null) {
 				val.children = new List<ObjectValue> ();
@@ -182,7 +181,6 @@ namespace Mono.Debugging.Client
 			var val = Create (null, path, null);
 			val.flags = flags | ObjectValueFlags.Evaluating;
 			val.updater = updater;
-			val.path = path;
 			return val;
 		}
 

--- a/Mono.Debugging/Mono.Debugging.Evaluation/BaseBacktrace.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/BaseBacktrace.cs
@@ -210,12 +210,15 @@ namespace Mono.Debugging.Evaluation
 			if (Adaptor.IsEvaluating) {
 				var values = new List<ObjectValue> ();
 
-				foreach (string exp in expressions) {
-					string tmpExp = exp;
+				foreach (var expression in expressions) {
+					string tmpExp = expression;
+
 					var value = Adaptor.CreateObjectValueAsync (tmpExp, ObjectValueFlags.Field, delegate {
-						EvaluationContext cctx = GetEvaluationContext (frameIndex, options);
+						var cctx = GetEvaluationContext (frameIndex, options);
 						return Adaptor.GetExpressionValue (cctx, tmpExp);
 					});
+					value.Name = expression;
+
 					values.Add (value);
 				}
 

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -1413,9 +1413,14 @@ namespace Mono.Debugging.Evaluation
 		public ObjectValue GetExpressionValue (EvaluationContext ctx, string exp)
 		{
 			try {
-				ValueReference var = ctx.Evaluator.Evaluate (ctx, exp);
+				var var = ctx.Evaluator.Evaluate (ctx, exp);
 
-				return var != null ? var.CreateObjectValue (ctx.Options) : ObjectValue.CreateUnknown (exp);
+				if (var == null)
+					return ObjectValue.CreateUnknown (exp);
+
+				var value = var.CreateObjectValue (ctx.Options);
+				value.Name = exp;
+				return value;
 			} catch (ImplicitEvaluationDisabledException) {
 				return ObjectValue.CreateImplicitNotSupported (ctx.ExpressionValueSource, new ObjectPath (exp), "", ObjectValueFlags.None);
 			} catch (NotSupportedExpressionException ex) {


### PR DESCRIPTION
This is what the old Gtk-based ObjectValueTreeView was doing
at a higher level, but that was always a hack.

This is a better way of doing it.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/993192/