### PR TITLE
Exposed ExceptionEventRequest

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/Catchpoint.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Catchpoint.cs
@@ -45,7 +45,7 @@ namespace Mono.Debugging.Client
 			this.exceptionName = exceptionName;
 			this.includeSubclasses = includeSubclasses;
 		}
-		
+
 		internal Catchpoint (XmlElement elem, string baseDir): base (elem, baseDir)
 		{
 			exceptionName = elem.GetAttribute ("exceptionName");
@@ -75,7 +75,7 @@ namespace Mono.Debugging.Client
 			get { return includeSubclasses; }
 			set { includeSubclasses = value; }
 		}
-		
+
 		public override void CopyFrom (BreakEvent ev)
 		{
 			base.CopyFrom (ev);


### PR DESCRIPTION
In Visual Studio in Windows there is no concept of a Catchpoint. I'm exposing the Exception Event Requests so we can use them directly.