### PR TITLE
Creating a new version of MOD_KIND_EXCEPTION_ONLY to support Not Filt…

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -305,6 +305,12 @@ namespace Mono.Debugger.Soft
 		public bool Subclasses {
 			get; set;
 		}
+		public bool NotFilteredFeature {
+			get; set;
+		}
+		public bool EverythingElse {
+			get; set;
+		}
 	}
 
 	class AssemblyModifier : Modifier {
@@ -427,7 +433,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 52;
+		internal const int MINOR_VERSION = 54;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -2489,6 +2495,10 @@ namespace Mono.Debugger.Soft
 							w.WriteBool (em.Subclasses);
 						} else if (!em.Subclasses) {
 							throw new NotSupportedException ("This request is not supported by the protocol version implemented by the debuggee.");
+						}
+						if (Version.MajorVersion > 2 || Version.MinorVersion >= 54) {
+							w.WriteBool (em.NotFilteredFeature);
+							w.WriteBool (em.EverythingElse);
 						}
 					} else if (mod is AssemblyModifier) {
 						w.WriteByte ((byte)ModifierKind.ASSEMBLY_ONLY);

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ExceptionEventRequest.cs
@@ -6,9 +6,9 @@ namespace Mono.Debugger.Soft
 	public sealed class ExceptionEventRequest : EventRequest {
 
 		TypeMirror exc_type;
-		bool caught, uncaught, subclasses;
+		bool caught, uncaught, subclasses, not_filtered_feature, everything_else;
 		
-		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught) : base (vm, EventType.Exception) {
+		internal ExceptionEventRequest (VirtualMachine vm, TypeMirror exc_type, bool caught, bool uncaught, bool not_filtered_feature = false, bool everything_else = false) : base (vm, EventType.Exception) {
 			if (exc_type != null) {
 				CheckMirror (vm, exc_type);
 				TypeMirror exception_type = vm.RootDomain.Corlib.GetType ("System.Exception", false, false);
@@ -19,6 +19,8 @@ namespace Mono.Debugger.Soft
 			this.caught = caught;
 			this.uncaught = uncaught;
 			this.subclasses = true;
+			this.not_filtered_feature = not_filtered_feature;
+			this.everything_else = everything_else;
 		}
 
 		public TypeMirror ExceptionType {
@@ -41,7 +43,7 @@ namespace Mono.Debugger.Soft
 
 		public override void Enable () {
 			var mods = new List <Modifier> ();
-			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses });
+			mods.Add (new ExceptionModifier () { Type = exc_type != null ? exc_type.Id : 0, Caught = caught, Uncaught = uncaught, Subclasses = subclasses, NotFilteredFeature = not_filtered_feature, EverythingElse = everything_else });
 			SendReq (mods);
 		}
 	}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -263,6 +263,12 @@ namespace Mono.Debugger.Soft
 			return new ExceptionEventRequest (this, exc_type, caught, uncaught);
 		}
 
+		public ExceptionEventRequest CreateExceptionRequest (TypeMirror exc_type, bool caught, bool uncaught, bool everything_else) {
+			if (Version.AtLeast (2, 54))
+				return new ExceptionEventRequest (this, exc_type, caught, uncaught, true, everything_else);
+			else
+				return new ExceptionEventRequest (this, exc_type, caught, uncaught);
+		}
 		public AssemblyLoadEventRequest CreateAssemblyLoadRequest () {
 			return new AssemblyLoadEventRequest (this);
 		}


### PR DESCRIPTION
…ered Exception feature, discussed with Joaquin Jares.

Because we don't have this functionality of get every other exception that is not specified, VsWin was getting every exception and filtering later. But this causes a slowness during the debugger because we stop all thread on each exception that we get, even if they are caught and we don't want to stop.

This fix a bug of slowness on Android Debugger.