### PR TITLE
[Mono.Debugging] Fixed ObjectValue.Refresh() to emit ValueChanged event

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
@@ -717,9 +717,8 @@ namespace Mono.Debugging.Client
 		public event EventHandler ValueChanged {
 			add {
 				lock (mutex) {
-					if (IsEvaluating)
-						valueChanged += value;
-					else
+					valueChanged += value;
+					if (!IsEvaluating)
 						value (this, EventArgs.Empty);
 				}
 			}
@@ -753,7 +752,7 @@ namespace Mono.Debugging.Client
 				return;
 
 			var val = source.GetValue (path, options);
-			UpdateFrom (val, false);
+			UpdateFrom (val, true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This will be needed for some upcoming fixes to the Cocoa ObjectValueTreeView