### PR TITLE
Remove last packages.config from unit test project

### DIFF
--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/MonoDevelop.Debugger.Tests.TestApp.csproj
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/MonoDevelop.Debugger.Tests.TestApp.csproj
@@ -10,8 +10,6 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <PackagesPath>packages\</PackagesPath>
-    <PackagesPath Condition="'$(SolutionDir)'!='*Undefined*'">$(SolutionDir)$(PackagesPath)</PackagesPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
@@ -66,9 +64,9 @@
     <Reference Include="MonoDevelop.Debugger.Tests.NonUserCodeTestLib">
       <HintPath>..\MonoDevelop.Debugger.Tests.NonUserCodeTestLib\bin\Debug\MonoDevelop.Debugger.Tests.NonUserCodeTestLib.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>$(PackagesPath)System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-    </Reference>
+   </ItemGroup>
+   <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -88,8 +86,5 @@
       <Project>{7A55BE57-81C9-45EC-9C7C-7F97D0508171}</Project>
       <Name>MonoDevelop.Debugger.Tests.AppDomainClient</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestApp/packages.config
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestApp/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
This allows debugger-libs to build with MSBuild-integrated restore.