### PR TITLE
Only resume VM when suspended.

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1731,7 +1731,8 @@ namespace Mono.Debugging.Soft
 			}
 
 			try {
-				vm.Resume ();
+				if (es.SuspendPolicy != SuspendPolicy.None)
+					vm.Resume ();
 			} catch (VMNotSuspendedException) {
 				if (type != EventType.VMStart && vm.Version.AtLeast (2, 2))
 					throw;


### PR DESCRIPTION
Running VM with suspend="n" (for late attach scenarios), raise a number of errors in debugger client. This is due to runtime not being suspended for several events, but debugger client didn't check the suspend policy returned by VM and always tried to do a resume triggering a VMNotSuspendedException for several different event types.

Fix is to check the returned suspend policy (since that indicates if VM is in a suspend state or not) and only resume when suspended.