### PR TITLE
After the new implementation of exception filters, we need to check t…

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1260,8 +1260,13 @@ namespace Mono.Debugging.Soft
 			lock (exceptionRequests) {
 				if (!types.ContainsKey (exceptionType)) {
 					if (vm.Version.AtLeast (2, 9)) {
-						foreach (TypeMirror t in vm.GetTypes (exceptionType, false))
-							ProcessType (t);
+						try {
+							foreach (TypeMirror t in vm.GetTypes (exceptionType, false))
+								ProcessType (t);
+						}
+						catch (CommandException exc) {
+							OnDebuggerOutput (false, string.Format ("Error while parsing type ‘{0}’.\n", exceptionType));
+						}
 					}
 				}
 


### PR DESCRIPTION
…he types that are passed by user and the ones that are already in the exception list, and we can receive some wrong information like a exceptionType = "test[" this is not possible to be parsed so we will get and INVALID_ARGUMENT exception, this PR is logging this information and ignoring the error, because this shouldn't stop the debug process. (#270)