### PR TITLE
[d16-4] Separate out calls to OnXxxxx from locking `breakpoints`

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -648,46 +648,54 @@ namespace Mono.Debugging.Client
 
 		bool RemoveBreakEvent (BreakEvent be)
 		{
+			BreakEventInfo binfo = null;
 			lock (breakpoints) {
-				BreakEventInfo binfo;
-				if (breakpoints.TryGetValue (be, out binfo)) {
-					try {
-						OnRemoveBreakEvent (binfo);
-					} catch (Exception ex) {
-						if (IsConnected)
-							OnDebuggerOutput (false, ex.Message);
-						HandleException (ex);
-						return false;
-					}
-					breakpoints.Remove (be);
-				}
-				return true;
+				if (!breakpoints.TryGetValue (be, out binfo))
+					return true;
+
+				breakpoints.Remove (be);
 			}
+
+			if (binfo != null) {
+				try {
+					OnRemoveBreakEvent (binfo);
+				} catch (Exception ex) {
+					if (IsConnected)
+						OnDebuggerOutput (false, ex.Message);
+					HandleException (ex);
+					return false;
+				}
+			}
+
+			return true;
 		}
-		
+
 		void UpdateBreakEventStatus (BreakEvent be)
 		{
+			BreakEventInfo binfo = null;
 			lock (breakpoints) {
-				BreakEventInfo binfo;
-				if (breakpoints.TryGetValue (be, out binfo)) {
-					try {
-						OnEnableBreakEvent (binfo, be.Enabled);
-					} catch (Exception ex) {
-						if (IsConnected)
-							OnDebuggerOutput (false, ex.Message);
-						HandleException (ex);
-					}
-				}
+				if (!breakpoints.TryGetValue (be, out binfo))
+					return;
+			}
+
+			try {
+				OnEnableBreakEvent (binfo, be.Enabled);
+			} catch (Exception ex) {
+				if (IsConnected)
+					OnDebuggerOutput (false, ex.Message);
+				HandleException (ex);
 			}
 		}
 		
 		void UpdateBreakEvent (BreakEvent be)
 		{
+			BreakEventInfo binfo;
 			lock (breakpoints) {
-				BreakEventInfo binfo;
-				if (breakpoints.TryGetValue (be, out binfo))
-					OnUpdateBreakEvent (binfo);
+				if (!breakpoints.TryGetValue (be, out binfo))
+					return;
 			}
+
+			OnUpdateBreakEvent (binfo);
 		}
 		
 		void OnBreakpointAdded (object s, BreakEventArgs args)


### PR DESCRIPTION
Fixes VSTS 1026593
[FATAL] SigTerm signal in Mono.Debugging.dll!Mono.Debugging.Client.DebuggerSession::GetBreakEventStatus+11

We can deadlock if we allow subclasses to perform arbitrary code inside locks.

This is a backport of PR #268