### PR TITLE
[DebuggerSession] Avoid using a dispatch queue for stepping

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1577,7 +1577,6 @@ namespace Mono.Debugging.Soft
 
 		void Step (StepDepth depth, StepSize size)
 		{
-
 			ThreadPool.QueueUserWorkItem (delegate {
 				try {
 					Adaptor.CancelAsyncOperations (); // This call can block, so it has to run in background thread to avoid keeping the main session lock

--- a/Mono.Debugging/Mono.Debugging.Backend/IRawValue.cs
+++ b/Mono.Debugging/Mono.Debugging.Backend/IRawValue.cs
@@ -29,7 +29,6 @@ using Mono.Debugging.Client;
 
 namespace Mono.Debugging.Backend
 {
-	
 	public interface IRawValue: IDebuggerBackendObject
 	{
 		object CallMethod (string name, object[] parameters, EvaluationOptions options);
@@ -37,5 +36,4 @@ namespace Mono.Debugging.Backend
 		object GetMemberValue (string name, EvaluationOptions options);
 		void SetMemberValue (string name, object value, EvaluationOptions options);
 	}
-	
 }

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -500,16 +500,14 @@ namespace Mono.Debugging.Client
 		{
 			lock (slock) {
 				OnRunning ();
-				Dispatch (delegate {
-					StartStepTimer (StepOverStats);
-					try {
-						OnNextLine ();
-					} catch (Exception ex) {
-						ForceStop ();
-						if (!HandleException (ex))
-							throw;
-					}
-				});
+				StartStepTimer (StepOverStats);
+				try {
+					OnNextLine ();
+				} catch (Exception ex) {
+					ForceStop ();
+					if (!HandleException (ex))
+						throw;
+				}
 			}
 		}
 
@@ -520,16 +518,14 @@ namespace Mono.Debugging.Client
 		{
 			lock (slock) {
 				OnRunning ();
-				Dispatch (delegate {
-					StartStepTimer (StepInStats);
-					try {
-						OnStepLine ();
-					} catch (Exception ex) {
-						ForceStop ();
-						if (!HandleException (ex))
-							throw;
-					}
-				});
+				StartStepTimer (StepInStats);
+				try {
+					OnStepLine ();
+				} catch (Exception ex) {
+					ForceStop ();
+					if (!HandleException (ex))
+						throw;
+				}
 			}
 		}
 		
@@ -540,16 +536,14 @@ namespace Mono.Debugging.Client
 		{
 			lock (slock) {
 				OnRunning ();
-				Dispatch (delegate {
-					StartStepTimer (NextInstructionStats);
-					try {
-						OnNextInstruction ();
-					} catch (Exception ex) {
-						ForceStop ();
-						if (!HandleException (ex))
-							throw;
-					}
-				});
+				StartStepTimer (NextInstructionStats);
+				try {
+					OnNextInstruction ();
+				} catch (Exception ex) {
+					ForceStop ();
+					if (!HandleException (ex))
+						throw;
+				}
 			}
 		}
 
@@ -560,16 +554,14 @@ namespace Mono.Debugging.Client
 		{
 			lock (slock) {
 				OnRunning ();
-				Dispatch (delegate {
-					StartStepTimer (StepInstructionStats);
-					try {
-						OnStepInstruction ();
-					} catch (Exception ex) {
-						ForceStop ();
-						if (!HandleException (ex))
-							throw;
-					}
-				});
+				StartStepTimer (StepInstructionStats);
+				try {
+					OnStepInstruction ();
+				} catch (Exception ex) {
+					ForceStop ();
+					if (!HandleException (ex))
+						throw;
+				}
 			}
 		}
 		
@@ -580,18 +572,16 @@ namespace Mono.Debugging.Client
 		{
 			lock (slock) {
 				OnRunning ();
-				Dispatch (delegate {
-					StartStepTimer (StepOutStats);
-					try {
-						OnFinish ();
-					} catch (Exception ex) {
-						// should handle exception before raising Exit event because HandleException may ignore exceptions in Exited state
-						var exceptionHandled = HandleException (ex);
-						ForceExit ();
-						if (!exceptionHandled)
-							throw;
-					}
-				});
+				StartStepTimer (StepOutStats);
+				try {
+					OnFinish ();
+				} catch (Exception ex) {
+					// should handle exception before raising Exit event because HandleException may ignore exceptions in Exited state
+					var exceptionHandled = HandleException (ex);
+					ForceExit ();
+					if (!exceptionHandled)
+						throw;
+				}
 			}
 		}
 


### PR DESCRIPTION
Just have the backends asynchronously send the request to the
remote app/run time (SoftDebuggerSession already does this).

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/804257/