### PR TITLE
Remove the need to have locking for DebuggerSession.Breakpoints

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -118,7 +118,7 @@ namespace Mono.Debugging.Soft
 			get; private set;
 		}
 
-		public SoftDebuggerSession ()
+		public SoftDebuggerSession (BreakpointStore breakpoints) : base (breakpoints)
 		{
 			Adaptor = CreateSoftDebuggerAdaptor ();
 			Adaptor.BusyStateChanged += (sender, e) => SetBusyState (e);

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -51,12 +51,9 @@ namespace Mono.Debugging.Client
 		readonly Dictionary<string, string> resolvedExpressionCache = new Dictionary<string, string> ();
 		readonly InternalDebuggerSession frontend;
 		readonly object slock = new object ();
-		readonly object breakpointStoreLock = new object ();
-		BreakpointStore breakpointStore;
 		DebuggerSessionOptions options;
 		ProcessInfo[] currentProcesses;
 		ThreadInfo activeThread;
-		bool ownedBreakpointStore;
 		bool adjustingBreakpoints;
 		DebuggerTimer stepTimer;
 		bool disposed;
@@ -134,10 +131,18 @@ namespace Mono.Debugging.Client
 		/// </summary>
 		public event EventHandler<AssemblyEventArgs> AssemblyLoaded;
 		
-		protected DebuggerSession ()
+		protected DebuggerSession (BreakpointStore breakpoints)
 		{
-			UseOperationThread = true;
 			frontend = new InternalDebuggerSession (this);
+			UseOperationThread = true;
+			Breakpoints = breakpoints;
+
+			breakpoints.BreakEventAdded += OnBreakpointAdded;
+			breakpoints.BreakEventRemoved += OnBreakpointRemoved;
+			breakpoints.BreakEventModified += OnBreakpointModified;
+			breakpoints.BreakEventEnableStatusChanged += OnBreakpointStatusChanged;
+			breakpoints.CheckingReadOnly += BreakpointStoreCheckingReadOnly;
+
 			EvaluationStats = new DebuggerStatistics ();
 			StepInStats = new DebuggerStatistics ();
 			StepOutStats = new DebuggerStatistics ();
@@ -165,8 +170,18 @@ namespace Mono.Debugging.Client
 			Dispatch (delegate {
 				if (!disposed) {
 					disposed = true;
-					if (!ownedBreakpointStore)
-						Breakpoints = null;
+
+					foreach (BreakEvent bp in Breakpoints) {
+						RemoveBreakEvent (bp);
+						NotifyBreakEventStatusChanged (bp);
+					}
+
+					Breakpoints.BreakEventAdded -= OnBreakpointAdded;
+					Breakpoints.BreakEventRemoved -= OnBreakpointRemoved;
+					Breakpoints.BreakEventModified -= OnBreakpointModified;
+					Breakpoints.BreakEventEnableStatusChanged -= OnBreakpointStatusChanged;
+					Breakpoints.CheckingReadOnly -= BreakpointStoreCheckingReadOnly;
+					Breakpoints.ResetBreakpoints ();
 				}
 			});
 		}
@@ -271,52 +286,7 @@ namespace Mono.Debugging.Client
 		/// Gets or sets the breakpoint store for the debugger session.
 		/// </summary>
 		public BreakpointStore Breakpoints {
-			get {
-				lock (breakpointStoreLock) {
-					if (breakpointStore == null) {
-						Breakpoints = new BreakpointStore ();
-						ownedBreakpointStore = true;
-					}
-					return breakpointStore;
-				}
-			}
-			set {
-				lock (breakpointStoreLock) {
-					if (breakpointStore != null) {
-						foreach (BreakEvent bp in breakpointStore) {
-							RemoveBreakEvent (bp);
-							NotifyBreakEventStatusChanged (bp);
-						}
-
-						breakpointStore.BreakEventAdded -= OnBreakpointAdded;
-						breakpointStore.BreakEventRemoved -= OnBreakpointRemoved;
-						breakpointStore.BreakEventModified -= OnBreakpointModified;
-						breakpointStore.BreakEventEnableStatusChanged -= OnBreakpointStatusChanged;
-						breakpointStore.CheckingReadOnly -= BreakpointStoreCheckingReadOnly;
-						breakpointStore.ResetBreakpoints ();
-					}
-
-					breakpointStore = value;
-					ownedBreakpointStore = false;
-
-					if (breakpointStore != null) {
-						breakpointStore.BreakEventAdded += OnBreakpointAdded;
-						breakpointStore.BreakEventRemoved += OnBreakpointRemoved;
-						breakpointStore.BreakEventModified += OnBreakpointModified;
-						breakpointStore.BreakEventEnableStatusChanged += OnBreakpointStatusChanged;
-						breakpointStore.CheckingReadOnly += BreakpointStoreCheckingReadOnly;
-
-						if (IsConnected) {
-							Dispatch (delegate {
-								if (IsConnected) {
-									foreach (BreakEvent bp in breakpointStore)
-										AddBreakEvent (bp);
-								}
-							});
-						}
-					}
-				}
-			}
+			get; private set;
 		}
 
 		readonly Queue<Action> actionsQueue = new Queue<Action>();
@@ -1227,10 +1197,8 @@ namespace Mono.Debugging.Client
 			lock (slock) {
 				if (!HasExited) {
 					IsConnected = true;
-					if (breakpointStore != null) {
-						foreach (BreakEvent bp in breakpointStore)
-							AddBreakEvent (bp);
-					}
+					foreach (BreakEvent bp in Breakpoints)
+						AddBreakEvent (bp);
 				}
 			}
 		}

--- a/UnitTests/Mono.Debugging.Tests/Shared/DebuggerSessionTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/DebuggerSessionTests.cs
@@ -53,7 +53,7 @@ namespace Mono.Debugging.Tests
 
 		[Test]
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
-		public async Task WhenQueryigBreakpoints_ThenDoNotDeadlockDispatchedMethods()
+		public async Task WhenQueryingBreakpoints_ThenDoNotDeadlockDispatchedMethods()
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
 		{
 			// thread 1 cancels debugging, which triggers hot reload to clear breakpoints 
@@ -88,6 +88,10 @@ namespace Mono.Debugging.Tests
 		class TestDebuggerSession : DebuggerSession
 		{
 			public Action HandleOnExit;
+
+			public TestDebuggerSession () : base (new BreakpointStore ())
+			{
+			}
 
 			protected override void OnAttachToProcess (long processId)
 			{


### PR DESCRIPTION
Setting up the breakpoint store in the .ctor allows us to remove the complexity of DebuggerSession.set_Breakpoints() which isn't really needed anyway since the breakpoints are only ever set immediately after creating the session.