### PR TITLE
Invalidating stack when calling abort of invoke method.

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -2805,6 +2805,7 @@ namespace Mono.Debugging.Soft
 
 		public override void Abort ()
 		{
+			var ctx = (SoftEvaluationContext)EvaluationContext;
 			if (handle is IInvokeAsyncResult) {
 				var info = GetInfo ();
 				DebuggerLoggingService.LogMessage ("Aborting invocation of " + info);

--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -2809,6 +2809,7 @@ namespace Mono.Debugging.Soft
 				var info = GetInfo ();
 				DebuggerLoggingService.LogMessage ("Aborting invocation of " + info);
 				((IInvokeAsyncResult) handle).Abort ();
+				ctx.Session.StackVersion++;
 				// Don't wait for the abort to finish. The engine will do it.
 			} else {
 				throw new NotSupportedException ();


### PR DESCRIPTION
Trying to fix this call stack.
Mono.Debugger.Soft.InvalidStackFrameException: The requested operation cannot be completed because the specified stack frame is no longer valid.
  at Mono.Debugger.Soft.VirtualMachine.ErrorHandler (System.Object sender, Mono.Debugger.Soft.ErrorHandlerEventArgs args) [0x0003e] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs:340 
  at Mono.Debugger.Soft.Connection.SendReceive (Mono.Debugger.Soft.Connection+CommandSet command_set, System.Int32 command, Mono.Debugger.Soft.Connection+PacketWriter packet) [0x000aa] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs:1645 
  at Mono.Debugger.Soft.Connection.StackFrame_GetDomain (System.Int64 thread_id, System.Int64 id) [0x00000] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs:2557 
  at Mono.Debugger.Soft.StackFrame.get_Domain () [0x0001d] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugger.Soft/Mono.Debugger.Soft/StackFrame.cs:41 
  at Mono.Debugging.Soft.SoftEvaluationContext..ctor (Mono.Debugging.Soft.SoftDebuggerSession session, Mono.Debugger.Soft.StackFrame frame, Mono.Debugging.Client.EvaluationOptions options) [0x0001a] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftEvaluationContext.cs:50 
  at Mono.Debugging.Soft.SoftDebuggerBacktrace.GetEvaluationContext (System.Int32 frameIndex, Mono.Debugging.Client.EvaluationOptions options) [0x0001c] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs:220 
  at Mono.Debugging.Soft.SoftDebuggerBacktrace.CreateStackFrame (Mono.Debugger.Soft.StackFrame frame, System.Int32 frameIndex) [0x00222] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs:176 
  at Mono.Debugging.Soft.SoftDebuggerBacktrace.GetStackFrames (System.Int32 firstIndex, System.Int32 lastIndex) [0x00020] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs:85 
  at Mono.Debugging.Client.Backtrace.GetFrame (System.Int32 index, System.Int32 fetchMultipleCount) [0x00021] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging/Mono.Debugging.Client/Backtrace.cs:57 
  at Mono.Debugging.Client.Backtrace.GetFrame (System.Int32 n) [0x00000] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging/Mono.Debugging.Client/Backtrace.cs:48 
  at MonoDevelop.Debugger.StackTracePadWidget.GetStackFrames () [0x00010] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/StackTracePad.cs:226 
  at MonoDevelop.Debugger.StackTracePadWidget+<>c.<Update>b__24_0 () [0x00000] in /Users/vsts/agent/2.158.0/work/1/s/monodevelop/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/StackTracePad.cs:251 
  at System.Threading.Tasks.Task`1[TResult].InnerInvoke () [0x0000f] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-06/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs:534 
  at System.Threading.Tasks.Task.Execute () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-06/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2319 
--- End of stack trace from previous location where exception was thrown ---

Trying to avoid this: https://github.com/mono/mono/pull/17354