### PR TITLE
[d16-5] null-protect stepTimer.Stop()/Dispose() in DebuggerSession.OnTargetEv…

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -1195,10 +1195,12 @@ namespace Mono.Debugging.Client
 			if (args.Thread != null && args.IsStopEvent)
 				activeThread = args.Thread;
 
-			if (stepTimer != null && (HasExited || args.IsStopEvent)) {
-				stepTimer.Stop (true);
-				stepTimer.Dispose ();
-				stepTimer = null;
+			if (HasExited || args.IsStopEvent) {
+				var timer = Interlocked.Exchange (ref stepTimer, null);
+				if (timer != null) {
+					timer.Stop (true);
+					timer.Dispose ();
+				}
 			}
 
 			evnt?.Invoke (this, args);


### PR DESCRIPTION
…ent()

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1060768/

Backport of https://github.com/mono/debugger-libs/pull/289