### PR TITLE
[UnitTests] Added helper GetAllLocalsSync() method

### DIFF
--- a/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/AdvancedEvaluationTests.cs
@@ -106,7 +106,7 @@ namespace Mono.Debugging.Tests
 			Assert.AreEqual ("23", val.Value);
 
 			var frame = Session.ActiveThread.Backtrace.GetFrame (0);
-			var locals = frame.GetAllLocals ();
+			var locals = frame.GetAllLocalsSync ();
 			Assert.AreEqual (4, locals.Length);
 
 			val = locals.Single (l => l.Name == "a");
@@ -139,7 +139,7 @@ namespace Mono.Debugging.Tests
 			Assert.AreEqual ("17", val.Value);
 
 			var frame = Session.ActiveThread.Backtrace.GetFrame (0);
-			var locals = frame.GetAllLocals ();
+			var locals = frame.GetAllLocalsSync ();
 			Assert.AreEqual (3, locals.Length);
 
 			val = locals.Single (l => l.Name == "a");
@@ -168,7 +168,7 @@ namespace Mono.Debugging.Tests
 			Assert.AreEqual ("5", val.Value);
 
 			var frame = Session.ActiveThread.Backtrace.GetFrame (0);
-			var locals = frame.GetAllLocals ();
+			var locals = frame.GetAllLocalsSync ();
 			Assert.AreEqual (2, locals.Length);
 
 			val = locals.Single (l => l.Name == "a");

--- a/UnitTests/Mono.Debugging.Tests/Shared/DebugTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/DebugTests.cs
@@ -468,5 +468,20 @@ namespace Mono.Debugging.Tests
 			}
 			return children;
 		}
+
+		public static ObjectValue[] GetAllLocalsSync(this StackFrame frame)
+		{
+			var locals = new List<ObjectValue> ();
+			var values = frame.GetAllLocals ();
+			for (int i = 0; i < values.Length; i++) {
+				var value = values[i].Sync ();
+
+				if (value.IsEvaluatingGroup)
+					locals.AddRange (value.GetAllChildrenSync ());
+				else
+					locals.Add (value);
+			}
+			return locals.ToArray ();
+		}
 	}
 }


### PR DESCRIPTION
This patch is needed by a fix to the VSCodeDebugProtocol backend unit tests

This change effectively just makes sure that all of the Local Variable
objects are fetched synchronously. When a debugger backend's GetAllLocals()
implementation returns an EvalutingGroup dummy variable so that the local
variables can be fetched asynchronously, the new GetAllLocalsSync() method
will evaluate & replace that EvaluatingGroup dummy variable with the real
list of local variables that the unit tests expect to find.