### PR TITLE
[debugger] Implementing step through multithreaded code.

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
@@ -34,6 +34,11 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
+		public int getId ()
+		{
+			return id;
+		}
+
 		public EventType EventType {
 			get {
 				return etype;

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
@@ -34,7 +34,7 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
-		public int getId ()
+		public int GetId ()
 		{
 			return id;
 		}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -613,9 +613,9 @@ namespace Mono.Debugger.Soft
 
 		internal EventRequest GetRequest (int id) {
 			lock (requests_lock) {
-				if (requests.ContainsKey(id))
-					return requests [id];
-				return null;
+				EventRequest obj;
+				requests.TryGetValue (id, out obj);
+				return obj;
 			}
 		}
 

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -613,7 +613,9 @@ namespace Mono.Debugger.Soft
 
 		internal EventRequest GetRequest (int id) {
 			lock (requests_lock) {
-				return requests [id];
+				if (requests.ContainsKey(id))
+					return requests [id];
+				return null;
 			}
 		}
 

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1948,10 +1948,10 @@ namespace Mono.Debugging.Soft
 						
 						if (hasBreakInfo) {
 							if (currentRequest != null &&
-								currentRequest is StepEventRequest &&
-								(currentRequest as StepEventRequest).Depth != StepDepth.Out &&
+								(currentRequest is StepEventRequest currentStepRequest) &&
+								currentStepRequest.Depth != StepDepth.Out &&
 								binfo.Location.ILOffset == currentAddress &&
-								e.Thread.Id == (currentRequest as StepEventRequest).Thread.Id &&
+								e.Thread.Id == currentStepRequest.Thread.Id &&
 								currentStackDepth == e.Thread.GetFrames ().Length)
 								redoCurrentStep = true;
 						}
@@ -1982,8 +1982,8 @@ namespace Mono.Debugging.Soft
 
 
 			if (redoCurrentStep) {
-				StepDepth depth = (currentRequest as StepEventRequest).Depth;
-				StepSize size = (currentRequest as StepEventRequest).Size;
+				StepDepth depth = ((StepEventRequest)currentRequest).Depth;
+				StepSize size = ((StepEventRequest)currentRequest).Size;
 
 				current_thread = recent_thread = es[0].Thread;
 

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1971,7 +1971,7 @@ namespace Mono.Debugging.Soft
 				}
 			}
 
-			if (currentRequest == null || (currentRequest != null && es[0] != null && es[0].Request != null && es[0].Request.getId () != currentRequest.getId ()))
+			if (currentRequest == null || (currentRequest != null && es[0] != null && es[0].Request != null && es[0].Request.GetId () != currentRequest.GetId ()))
 				currentRequest = es[0].Request;
 
 


### PR DESCRIPTION
I've changed the variable the_ss_req to an array, in this array I saved all the single steps requisitions received and whenever the debugger stops in a possible singles step I get the right requisition in the array and answer it.
It is necessary to change debugger-libs together, because we can send a single step for thread A and receive an answer of thread B, so we shouldn't cancel the single step requisition for thread A, because it wasn't answered yet.
If the change in debugger-libs is not synchronised together if mono we will not have any side effect, the multithreaded step just don't work as nowadays.

Fixes #14456
Relates to https://github.com/mono/mono/pull/19103