### PR TITLE
[debugger] NRE when 2 threads try to call GetThreads at same time

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -197,6 +197,7 @@ namespace Mono.Debugger.Soft
 				//if (threadCache != threads) {//While fetching threads threadCache was invalidated(thread was created/destoyed)
 				//	return GetThreads ();
 				//}
+				Thread.MemoryBarrier ();
 				threadCache = threads;
 				return threads;
 			} else {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -177,30 +177,32 @@ namespace Mono.Debugger.Soft
 		}
 
 		public IList<ThreadMirror> GetThreads () {
-			var threads = threadCache;
-			if (threads == null) {
-				long[] ids = null;
-				var fetchingEvent = new ManualResetEvent (false);
-				vm.conn.VM_GetThreads ((threadsIds) => {
-					ids = threadsIds;
-					threadCache = threads = new ThreadMirror [threadsIds.Length];
-					fetchingEvent.Set ();
-				});
-				if (WaitHandle.WaitAny (new []{ vm.conn.DisconnectedEvent, fetchingEvent }) == 0) {
-					throw new VMDisconnectedException ();
+			lock (threadCacheLocker) {
+				var threads = threadCache;
+				if (threads == null) {
+					long[] ids = null;
+					var fetchingEvent = new ManualResetEvent (false);
+					vm.conn.VM_GetThreads ((threadsIds) => {
+						ids = threadsIds;
+						threadCache = threads = new ThreadMirror [threadsIds.Length];
+						fetchingEvent.Set ();
+					});
+					if (WaitHandle.WaitAny (new []{ vm.conn.DisconnectedEvent, fetchingEvent }) == 0) {
+						throw new VMDisconnectedException ();
+					}
+					for (int i = 0; i < ids.Length; ++i)
+						threads [i] = GetThread (ids [i]);
+					//Uncomment lines below if you want to re-fetch threads if new threads were started/stopped while
+					//featching threads... This is probably more correct but might cause deadlock of this method if runtime
+					//is starting/stopping threads nonstop, need way to prevent this(counting number of recursions?)
+					//possiblity before uncommenting
+					//if (threadCache != threads) {//While fetching threads threadCache was invalidated(thread was created/destoyed)
+					//	return GetThreads ();
+					//}
+					return threads;
+				} else {
+					return threads;
 				}
-				for (int i = 0; i < ids.Length; ++i)
-					threads [i] = GetThread (ids [i]);
-				//Uncomment lines below if you want to re-fetch threads if new threads were started/stopped while
-				//featching threads... This is probably more correct but might cause deadlock of this method if runtime
-				//is starting/stopping threads nonstop, need way to prevent this(counting number of recursions?)
-				//possiblity before uncommenting
-				//if (threadCache != threads) {//While fetching threads threadCache was invalidated(thread was created/destoyed)
-				//	return GetThreads ();
-				//}
-				return threads;
-			} else {
-				return threads;
 			}
 		}
 

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -154,7 +154,6 @@ namespace Mono.Debugger.Soft
 
 		HashSet<ThreadMirror> threadsToInvalidate = new HashSet<ThreadMirror> ();
 		ThreadMirror[] threadCache;
-		object threadCacheLocker = new object ();
 
 		void InvalidateThreadAndFrameCaches () {
 			lock (threadsToInvalidate) {
@@ -177,32 +176,31 @@ namespace Mono.Debugger.Soft
 		}
 
 		public IList<ThreadMirror> GetThreads () {
-			lock (threadCacheLocker) {
-				var threads = threadCache;
-				if (threads == null) {
-					long[] ids = null;
-					var fetchingEvent = new ManualResetEvent (false);
-					vm.conn.VM_GetThreads ((threadsIds) => {
-						ids = threadsIds;
-						threadCache = threads = new ThreadMirror [threadsIds.Length];
-						fetchingEvent.Set ();
-					});
-					if (WaitHandle.WaitAny (new []{ vm.conn.DisconnectedEvent, fetchingEvent }) == 0) {
-						throw new VMDisconnectedException ();
-					}
-					for (int i = 0; i < ids.Length; ++i)
-						threads [i] = GetThread (ids [i]);
-					//Uncomment lines below if you want to re-fetch threads if new threads were started/stopped while
-					//featching threads... This is probably more correct but might cause deadlock of this method if runtime
-					//is starting/stopping threads nonstop, need way to prevent this(counting number of recursions?)
-					//possiblity before uncommenting
-					//if (threadCache != threads) {//While fetching threads threadCache was invalidated(thread was created/destoyed)
-					//	return GetThreads ();
-					//}
-					return threads;
-				} else {
-					return threads;
+			var threads = threadCache;
+			if (threads == null) {
+				long[] ids = null;
+				var fetchingEvent = new ManualResetEvent (false);
+				vm.conn.VM_GetThreads ((threadsIds) => {
+					ids = threadsIds;
+					threads = new ThreadMirror [threadsIds.Length];
+					fetchingEvent.Set ();
+				});
+				if (WaitHandle.WaitAny (new []{ vm.conn.DisconnectedEvent, fetchingEvent }) == 0) {
+					throw new VMDisconnectedException ();
 				}
+				for (int i = 0; i < ids.Length; ++i)
+					threads [i] = GetThread (ids [i]);
+				//Uncomment lines below if you want to re-fetch threads if new threads were started/stopped while
+				//featching threads... This is probably more correct but might cause deadlock of this method if runtime
+				//is starting/stopping threads nonstop, need way to prevent this(counting number of recursions?)
+				//possiblity before uncommenting
+				//if (threadCache != threads) {//While fetching threads threadCache was invalidated(thread was created/destoyed)
+				//	return GetThreads ();
+				//}
+				threadCache = threads;
+				return threads;
+			} else {
+				return threads;
 			}
 		}
 


### PR DESCRIPTION
As analysed by @jstedfast and me the only way to get this exception with this callstack below is 2 threads call GetThreads at same time, so while one of them is filling the items in the array, the other one is already trying to use the array with null items.

```
System.NullReferenceException: Object reference not set to an instance of an object
  at Mono.Debugging.Soft.SoftDebuggerSession.GetId (Mono.Debugger.Soft.ThreadMirror thread) [0x00000] in /Users/runner/runners/2.164.6/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerSession.cs:3227
  at Mono.Debugging.Soft.SoftDebuggerSession.OnGetThreads (System.Int64 processId) [0x0002c] in /Users/runner/runners/2.164.6/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerSession.cs:879
  at Mono.Debugging.Soft.SoftDebuggerSession.GetThread (Mono.Debugging.Client.ProcessInfo process, Mono.Debugger.Soft.ThreadMirror thread) [0x00008] in /Users/runner/runners/2.164.6/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerSession.cs:902
  at Mono.Debugging.Soft.SoftDebuggerSession.HandleBreakEventSet (Mono.Debugger.Soft.Event[] es, System.Boolean dequeuing) [0x00501] in /Users/runner/runners/2.164.6/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerSession.cs:2038
  at Mono.Debugging.Soft.SoftDebuggerSession.HandleEventSet (Mono.Debugger.Soft.EventSet es) [0x0005b] in /Users/runner/runners/2.164.6/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerSession.cs:1687
  at Mono.Debugging.Soft.SoftDebuggerSession.EventHandler () [0x0005d] in /Users/runner/runners/2.164.6/work/1/s/monodevelop/main/external/debugger-libs/Mono.Debugging.Soft/SoftDebuggerSession.cs:1625
```

PR on mono/mono -> https://github.com/mono/mono/pull/19122

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1070384/
