### PR TITLE
[debugger] Fix set_value and get_value after invoke a method

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
@@ -356,7 +356,10 @@ namespace Mono.Debugger.Soft
 			} else {
 				if (r.Exception != null)
 					throw new InvocationException ((ObjectMirror)r.VM.DecodeValue (r.Exception));
-
+				
+				//refresh frames from thread after running an invoke
+				r.Thread.GetFrames();
+				
 				Value out_this = null;
 				if (r.OutThis != null)
 					out_this = r.VM.DecodeValue (r.OutThis);


### PR DESCRIPTION
When we run an invoke in a thread and after this we do a set_value and then a get_value, after the invoke we should refresh frames before calling set_value.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1077790
Relates https://github.com/mono/mono/pull/19378