### PR TITLE
[d16-5] disable sdb tests that fail on Catalina

### DIFF
--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbAdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbAdvancedEvaluationTests.cs
@@ -29,6 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbAdvancedEvaluationAllowTargetInvokesTests : AdvancedEvaluationTests
 	{
 		public SdbAdvancedEvaluationAllowTargetInvokesTests () : base ("Mono.Debugger.Soft", true)
@@ -37,6 +38,7 @@ namespace Mono.Debugging.Tests.Soft
 	}
 
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbAdvancedEvaluationNoTargetInvokesTests : AdvancedEvaluationTests
 	{
 		public SdbAdvancedEvaluationNoTargetInvokesTests () : base ("Mono.Debugger.Soft", false)

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbAdvancedEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbAdvancedEvaluationTests.cs
@@ -29,7 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbAdvancedEvaluationAllowTargetInvokesTests : AdvancedEvaluationTests
 	{
 		public SdbAdvancedEvaluationAllowTargetInvokesTests () : base ("Mono.Debugger.Soft", true)
@@ -38,7 +38,7 @@ namespace Mono.Debugging.Tests.Soft
 	}
 
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbAdvancedEvaluationNoTargetInvokesTests : AdvancedEvaluationTests
 	{
 		public SdbAdvancedEvaluationNoTargetInvokesTests () : base ("Mono.Debugger.Soft", false)

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbBreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbBreakpointsAndSteppingTests.cs
@@ -29,6 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbBreakpointsAndSteppingTests: BreakpointsAndSteppingTests
 	{
 		public SdbBreakpointsAndSteppingTests () : base ("Mono.Debugger.Soft")

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbBreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbBreakpointsAndSteppingTests.cs
@@ -29,7 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbBreakpointsAndSteppingTests: BreakpointsAndSteppingTests
 	{
 		public SdbBreakpointsAndSteppingTests () : base ("Mono.Debugger.Soft")

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbCodeCompletionTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbCodeCompletionTests.cs
@@ -29,6 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbCodeCompletionTests : CodeCompletionTests
 	{
 		public SdbCodeCompletionTests () : base ("Mono.Debugger.Soft")

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbCodeCompletionTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbCodeCompletionTests.cs
@@ -29,7 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbCodeCompletionTests : CodeCompletionTests
 	{
 		public SdbCodeCompletionTests () : base ("Mono.Debugger.Soft")

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbEvaluationTests.cs
@@ -29,6 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbEvaluationAllowTargetInvokesTests: EvaluationTests
 	{
 		public SdbEvaluationAllowTargetInvokesTests (): base ("Mono.Debugger.Soft", true)
@@ -37,6 +38,7 @@ namespace Mono.Debugging.Tests.Soft
 	}
 
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbEvaluationNoTargetInvokesTests: EvaluationTests
 	{
 		public SdbEvaluationNoTargetInvokesTests (): base ("Mono.Debugger.Soft", false)

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbEvaluationTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbEvaluationTests.cs
@@ -29,7 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbEvaluationAllowTargetInvokesTests: EvaluationTests
 	{
 		public SdbEvaluationAllowTargetInvokesTests (): base ("Mono.Debugger.Soft", true)
@@ -38,7 +38,7 @@ namespace Mono.Debugging.Tests.Soft
 	}
 
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbEvaluationNoTargetInvokesTests: EvaluationTests
 	{
 		public SdbEvaluationNoTargetInvokesTests (): base ("Mono.Debugger.Soft", false)

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbStackFrameTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbStackFrameTests.cs
@@ -29,7 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbStackFrameAllowTargetInvokesTests : StackFrameTests
 	{
 		public SdbStackFrameAllowTargetInvokesTests (): base ("Mono.Debugger.Soft", true)
@@ -38,7 +38,7 @@ namespace Mono.Debugging.Tests.Soft
 	}
 
 	[TestFixture]
-	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090747")]
 	public class SdbStackFrameNoTargetInvokesTests : StackFrameTests
 	{
 		public SdbStackFrameNoTargetInvokesTests (): base ("Mono.Debugger.Soft", false)

--- a/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbStackFrameTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/Sdb/SdbStackFrameTests.cs
@@ -29,6 +29,7 @@ using NUnit.Framework;
 namespace Mono.Debugging.Tests.Soft
 {
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbStackFrameAllowTargetInvokesTests : StackFrameTests
 	{
 		public SdbStackFrameAllowTargetInvokesTests (): base ("Mono.Debugger.Soft", true)
@@ -37,6 +38,7 @@ namespace Mono.Debugging.Tests.Soft
 	}
 
 	[TestFixture]
+	[Ignore("Skipped due to issue https://work.azdo.io/1090662")]
 	public class SdbStackFrameNoTargetInvokesTests : StackFrameTests
 	{
 		public SdbStackFrameNoTargetInvokesTests (): base ("Mono.Debugger.Soft", false)


### PR DESCRIPTION
backport of https://github.com/mono/debugger-libs/pull/306