### PR TITLE
Fix possible NRE in ObjectValue.GetChild()

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
@@ -445,7 +445,7 @@ namespace Mono.Debugging.Client
 		/// </remarks>
 		public ObjectValue GetChild (string name)
 		{
-			return GetChild (name, parentFrame.DebuggerSession.EvaluationOptions);
+			return GetChild (name, parentFrame?.DebuggerSession.EvaluationOptions);
 		}
 		
 		/// <summary>


### PR DESCRIPTION
Fixes VSTS #1089298

I haven't been able to reproduce this NRE locally, but looking through the rest of the file I see a number of places that check `parentFrame` for null.

It looks like passing null in here should not cause problems further down in the code. This value gets passed into `EvaluationContext.WithOptions()` which properly handles `null`.