### PR TITLE
[Mono.Debugging] Fixed BaseBacktrace to uncache FrameInfo after evalu…

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Evaluation/BaseBacktrace.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/BaseBacktrace.cs
@@ -215,7 +215,12 @@ namespace Mono.Debugging.Evaluation
 
 					var value = Adaptor.CreateObjectValueAsync (tmpExp, ObjectValueFlags.Field, delegate {
 						var cctx = GetEvaluationContext (frameIndex, options);
-						return Adaptor.GetExpressionValue (cctx, tmpExp);
+						var result = Adaptor.GetExpressionValue (cctx, tmpExp);
+
+						// uncache the frame since values of local variables/params/etc may have changed.
+						frameInfo.Remove (frameIndex);
+
+						return result;
 					});
 					value.Name = expression;
 
@@ -226,8 +231,12 @@ namespace Mono.Debugging.Evaluation
 			}
 
 			var ctx = GetEvaluationContext (frameIndex, options);
+			var evaluated = ctx.Adapter.GetExpressionValuesAsync (ctx, expressions);
 
-			return ctx.Adapter.GetExpressionValuesAsync (ctx, expressions);
+			// uncache the frame since values of local variables/params/etc may have changed.
+			frameInfo.Remove (frameIndex);
+
+			return evaluated;
 		}
 		
 		public virtual CompletionData GetExpressionCompletionData (int frameIndex, string exp)


### PR DESCRIPTION
…ating expressions

This change fixes it so that evaluating epxressions in the Immediate Pad
causes the value to update in the Locals Pad as well.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1109965/