### PR TITLE
Added a method to be able to add user assemblies after init

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2032,16 +2032,23 @@ namespace Mono.Debugging.Soft
 			}
 		}
 
+		public void AddUserAssembly(string userAssembly)
+		{
+			if (userAssemblyNames != null && !userAssemblyNames.Contains(userAssembly))
+				userAssemblyNames.Add(userAssembly);
+		}
+
 		void HandleAssemblyLoadEvents (AssemblyLoadEvent[] events)
 		{
 			var asm = events [0].Assembly;
 			if (events.Length > 1 && events.Any (a => a.Assembly != asm))
 				throw new InvalidOperationException ("Simultaneous AssemblyLoadEvent for multiple assemblies");
-			RegisterAssembly (asm);
+
+			OnAssemblyLoaded(asm.Location);
+
+			RegisterAssembly(asm);
 			bool isExternal;
 			isExternal = !UpdateAssemblyFilters (asm) && userAssemblyNames != null;
-
-			OnAssemblyLoaded (asm.Location);
 
 			string flagExt = isExternal ? " [External]" : "";
 			OnDebuggerOutput (false, string.Format ("Loaded assembly: {0}{1}\n", asm.Location, flagExt));


### PR DESCRIPTION
In Visual Studio it is possible to Load Symbols for existing assemblies. This functionality results in new assemblies being debuggable in the middle of the debug session. I'm adding this method so I can use this functionality, but also to be able to load symbols as assemblies are loaded and not all at the same time, which make the debugger more responsive.