### PR TITLE
Since this is public API we can't add more abstract methods

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -1329,7 +1329,7 @@ namespace Mono.Debugger.Soft
 		protected abstract void TransportSetTimeouts (int send_timeout, int receive_timeout);
 		protected abstract void TransportClose ();
 		// Shutdown breaks all communication, resuming blocking waits
-		protected abstract void TransportShutdown ();
+		protected virtual void TransportShutdown () { }
 
 		internal VersionInfo Version;
 		


### PR DESCRIPTION
Hence add virtual so we don't break compatibility...