### PR TITLE
Fix 1153385: Mono debug session stops  responding and hangs if Theads pad is open

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
@@ -81,11 +81,13 @@ namespace Mono.Debugger.Soft
 		{
 			if (threads.Count == 0)
 				return;
-			threads [0].vm.conn.StartBuffering ();
-			foreach (var thread in threads) {
-				thread.FetchFrames ();
+			lock (threads[0].vm.conn) {
+				threads[0].vm.conn.StartBuffering ();
+				foreach (var thread in threads) {
+					thread.FetchFrames ();
+				}
+				threads[0].vm.conn.StopBuffering ();
 			}
-			threads [0].vm.conn.StopBuffering ();
 		}
 
 		public string Name {


### PR DESCRIPTION
Problem was that multiple threads were fetching threads causing Start/Stop buffering to be all over the place causing runtime to get stuck in buffering which meant not sending responses…