### PR TITLE
Added OutputOptions class

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -62,6 +62,8 @@ namespace Mono.Debugging.Client
 		bool disposed;
 		bool attached;
 
+		protected OutputOptions outputOptions;
+
 		/// <summary>
 		/// Reports a debugger event
 		/// </summary>
@@ -151,8 +153,9 @@ namespace Mono.Debugging.Client
 			CallStackPadUsageCounter = new UsageCounter ();
 			ImmediatePadUsageCounter = new UsageCounter ();
 			ThreadsPadUsageCounter = new UsageCounter ();
+			outputOptions = new OutputOptions { ExceptionMessage = true, ModuleLoaded = true, ModuleUnoaded = true, ProcessExited = true, SymbolSearch = true, ThreadExited = true };
 		}
-		
+
 		/// <summary>
 		/// Releases all resource used by the <see cref="Mono.Debugging.Client.DebuggerSession"/> object.
 		/// </summary>
@@ -173,7 +176,12 @@ namespace Mono.Debugging.Client
 				}
 			});
 		}
-		
+
+		public void SetOutputOptions(OutputOptions options)
+		{
+			outputOptions = options;
+		}
+
 		/// <summary>
 		/// Gets or sets an exception handler to be invoked when an exception is raised by the debugger engine.
 		/// </summary>
@@ -737,7 +745,7 @@ namespace Mono.Debugging.Client
 				try {
 					OnRemoveBreakEvent (binfo);
 				} catch (Exception ex) {
-					if (IsConnected)
+					if (IsConnected && outputOptions.ExceptionMessage)
 						OnDebuggerOutput (false, ex.Message);
 					HandleException (ex);
 					return false;
@@ -758,7 +766,7 @@ namespace Mono.Debugging.Client
 			try {
 				OnEnableBreakEvent (binfo, be.Enabled);
 			} catch (Exception ex) {
-				if (IsConnected)
+				if (IsConnected && outputOptions.ExceptionMessage)
 					OnDebuggerOutput (false, ex.Message);
 				HandleException (ex);
 			}
@@ -992,7 +1000,8 @@ namespace Mono.Debugging.Client
 				try {
 					resolved = OnResolveExpression (expression, location);
 				} catch (Exception ex) {
-					OnDebuggerOutput (true, "Error while resolving expression: " + ex.Message);
+					if (outputOptions.ExceptionMessage)
+						OnDebuggerOutput (true, "Error while resolving expression: " + ex.Message);
 				}
 				resolvedExpressionCache [key] = resolved;
 			}

--- a/Mono.Debugging/Mono.Debugging.Client/OutputOptions.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/OutputOptions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mono.Debugging.Client
+{
+	[Serializable]
+	public class OutputOptions
+	{
+		public bool ModuleLoaded { get; set; }
+		public bool ModuleUnoaded { get; set; }
+		public bool ExceptionMessage { get; set; }
+		public bool SymbolSearch { get; set; }
+		public bool ThreadExited { get; set; }
+		public bool ProcessExited { get; set; }
+
+	}
+}

--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -64,6 +64,7 @@
     <Compile Include="Mono.Debugging.Client\DebuggerSession.cs" />
     <Compile Include="Mono.Debugging.Client\Backtrace.cs" />
     <Compile Include="Mono.Debugging.Client\DebuggerStartInfo.cs" />
+    <Compile Include="Mono.Debugging.Client\OutputOptions.cs" />
     <Compile Include="Mono.Debugging.Client\ProcessEventArgs.cs" />
     <Compile Include="Mono.Debugging.Client\SourceLocation.cs" />
     <Compile Include="Mono.Debugging.Client\StackFrame.cs" />


### PR DESCRIPTION
VS has UI to select what to output in the debugger. There's a very
common request from our users to filter the output in mono apps, which
is usually very verbose. This commits adds that in a way that's
performant and accurate. The runtime will still show some unneeded
output, but this first step enables fixing that in the future.