### PR TITLE
Add support for subprocess debugging

### DIFF
--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -64,6 +64,7 @@
     <Compile Include="PortablePdbData.cs" />
     <Compile Include="SourceLinkMap.cs" />
     <Compile Include="JsonSourceLink.cs" />
+    <Compile Include="Subprocess.cs" />
   </ItemGroup>
   <PropertyGroup>
     <NuGetVersionRoslyn Condition="$(NuGetVersionRoslyn) == ''">2.10.0</NuGetVersionRoslyn>

--- a/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs
@@ -2686,7 +2686,7 @@ namespace Mono.Debugging.Soft
 				if (sm.Type.IsPrimitive) {
 					// Boxed primitive
 					if (sm.Type.FullName == "System.IntPtr")
-						return new EvaluationResult ("0x" + ((long)((PrimitiveValue)sm.Fields [0]).Value).ToString ("x"));
+						return new EvaluationResult ("0x" + ((long)((PointerValue)sm.Fields [0]).Address).ToString ("x"));
 					if (sm.Fields.Length > 0 && (sm.Fields[0] is PrimitiveValue))
 						return ((PrimitiveValue)sm.Fields[0]).Value;
 				} else if (sm.Type.FullName == "System.Decimal") {

--- a/Mono.Debugging.Soft/SoftDebuggerStartInfo.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerStartInfo.cs
@@ -209,5 +209,7 @@ namespace Mono.Debugging.Soft
 		public string MonoExecutableFileName { get; set; }
 		
 		public override ISoftDebuggerConnectionProvider ConnectionProvider { get { return null; } }
+
+		internal Mono.Debugger.Soft.LaunchOptions.ProcessLauncher CustomProcessLauncher { get; set; }
 	}
 }

--- a/Mono.Debugging.Soft/Subprocess.cs
+++ b/Mono.Debugging.Soft/Subprocess.cs
@@ -1,0 +1,223 @@
+//
+// Subprocess.cs
+//
+// Author:
+//       Lluis Sanchez <llsan@microsoft.com>
+//
+// Copyright (c) 2020 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Mono.Debugger.Soft;
+using Mono.Debugging.Backend;
+using Mono.Debugging.Client;
+using Mono.Debugging.Evaluation;
+
+namespace Mono.Debugging.Soft
+{
+	class Subprocess
+	{
+		const string ArgStartMarker = "_ARG_START_";
+		readonly SoftDebuggerSession softDebuggerSession;
+
+		ManualResetEvent launchingEvent = new ManualResetEvent (false);
+		ManualResetEvent startedEvent = new ManualResetEvent (false);
+
+		string arguments;
+		string exe;
+
+		int processId;
+		bool shutdown;
+
+		ProcessStartInfo debuggerStartInfo;
+
+		SoftDebuggerSession newSession;
+
+		public SoftDebuggerSession SubprocessSession => newSession;
+
+		public long ThreadId { get; private set; }
+
+		public Subprocess (long threadId, SoftDebuggerSession softDebuggerSession)
+		{
+			ThreadId = threadId;
+			this.softDebuggerSession = softDebuggerSession;
+		}
+
+		public static bool IsMonoLauncher (string filePath)
+		{
+			var exeName = Path.GetFileName (filePath);
+			return exeName == "mono" || exeName == "mono64";
+		}
+
+		public bool CreateSession (ValueReference startInfo, EvaluationOptions ops)
+		{
+			// Get the exe and arguments from the start info and store them
+			this.arguments = (string)startInfo.GetChild ("Arguments", ops).GetRawValue (ops);
+			this.exe = (string)startInfo.GetChild ("FileName", ops).GetRawValue (ops);
+
+			// Create the new session and custom start arguments.
+			// The actual arguments don't matter much since we'll use a custom launcher for the process.
+			newSession = new SoftDebuggerSession ();
+
+			var startArgs = new SoftDebuggerLaunchArgs (null, new Dictionary<string, string> ());
+			var dsi = new SoftDebuggerStartInfo (startArgs);
+
+			// A mono process can be launched either by providing "mono" as launcher and then the assembly name as argument,
+			// or by providing the assembly name directly as file to launch.
+
+			bool explicitMonoLaunch = IsMonoLauncher (exe);
+			if (explicitMonoLaunch) {
+				// Try to get the assembly name from the command line. The debug session uses what's provided
+				// in the Command property as process name. Without this, all mono processes launched in this
+				// way would show up as "mono" in the IDE.
+				var cmd = GetExeName (arguments);
+				if (cmd != null)
+					dsi.Command = cmd;
+
+				// The new session will add additional runtime arguments to the start info.
+				// We'll use the _ARG_START_ marker to know where those arguments end.
+				dsi.RuntimeArguments = ArgStartMarker;
+			} else {
+				dsi.Command = exe;
+				dsi.Arguments = arguments;
+			}
+
+			startArgs.CustomProcessLauncher = TargetProcessLauncher;
+
+			// Start the session. This will run asynchronously, and will at some point call the custom launcher specified just above.
+			newSession.Run (dsi, softDebuggerSession.Options);
+
+			// Wait for the session to ask for the process to be launched
+			launchingEvent.WaitOne ();
+			if (shutdown)
+				return false;
+
+			// The custom launcher will store the debugger agent configuration args in debuggerStartInfo.
+			// No the original startInfo object is patched to include the debugger agent args
+
+			if (explicitMonoLaunch) {
+				// Prepend the debugger args to the original arguments
+				int i = debuggerStartInfo.Arguments.IndexOf (ArgStartMarker);
+				var debuggerArgs = debuggerStartInfo.Arguments.Substring (0, i);
+				startInfo.GetChild ("Arguments", ops).SetRawValue (debuggerArgs + " " + arguments, ops);
+			} else {
+				startInfo.GetChild ("Arguments", ops).SetRawValue (debuggerStartInfo.Arguments, ops);
+				startInfo.GetChild ("FileName", ops).SetRawValue (debuggerStartInfo.FileName, ops);
+			}
+			return true;
+		}
+
+		Process TargetProcessLauncher (ProcessStartInfo info)
+		{
+			// This callback is called by the debug session to start the process.
+			// We won't actually launch the process here since the current process is already doing it,
+			// we just need to wait for the process to be launched by resuming execution, and then return
+			// a reference to that process.
+
+			// Store a reference to the start info provided to start the process. We need to retrieve the
+			// debug agent configuration arguments from it.
+			debuggerStartInfo = info;
+
+			info.RedirectStandardError = false;
+			info.RedirectStandardOutput = false;
+
+			// Signal that the session asked the process to be started (this will cause execution to be resumed,
+			// so the process will be launched)
+			launchingEvent.Set ();
+
+			// Wait for the process to start
+			startedEvent.WaitOne ();
+
+			// processId should be set now. We can now return the process that has launched.
+			var process = Process.GetProcessById (processId);
+			process.EnableRaisingEvents = true;
+			return process;
+		}
+
+		public void SetStarted (ValueReference startInfo, int id, EvaluationContext ctx)
+		{
+			// This is called after the process is launched.
+
+			// Store the process ID. It will be used by TargetProcessLauncher to get a reference to the process.
+			processId = id;
+
+			// Assign the original exe and arguments to the start info object
+			startInfo.GetChild ("Arguments", ctx.Options).SetRawValue (arguments, ctx.Options);
+			startInfo.GetChild ("FileName", ctx.Options).SetRawValue (exe, ctx.Options);
+
+			// Signal TargetProcessLauncher that the process has started and the process ID is available.
+			startedEvent.Set ();
+		}
+
+		public static string GetExeName (string monoCommandArgs)
+		{
+			foreach (var arg in GetArguments (monoCommandArgs)) {
+				if (arg.StartsWith ("--"))
+					continue;
+				var ext = Path.GetExtension (arg).ToLower ();
+				if ((ext == ".dll" || ext == ".exe") && File.Exists (arg))
+					return arg;
+			}
+			return null;
+		}
+
+		static IEnumerable<string> GetArguments (string monoCommandArgs)
+		{
+			bool inQuotes = false;
+			var currentString = new StringBuilder ();
+			for (int n = 0; n < monoCommandArgs.Length; n++) {
+				var c = monoCommandArgs[n];
+				if (c == '\\') {
+					if (n < monoCommandArgs.Length - 1 && (monoCommandArgs[n + 1] == '\\' || monoCommandArgs[n + 1] == '"')) {
+						currentString.Append (monoCommandArgs[n + 1]);
+						n++;
+					}
+				} else if (inQuotes) {
+					if (c == '"')
+						inQuotes = false;
+					else
+						currentString.Append (c);
+				} else if (c == '"') {
+					inQuotes = true;
+				} else if (char.IsWhiteSpace (c)) {
+					if (currentString.Length > 0) {
+						yield return currentString.ToString ();
+						currentString.Clear ();
+					}
+				} else
+					currentString.Append (c);
+			}
+			if (currentString.Length > 0)
+				yield return currentString.ToString ();
+		}
+
+		public void Shutdown ()
+		{
+			shutdown = true;
+			launchingEvent.Set ();
+			startedEvent.Set ();
+		}
+	}
+}

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -135,7 +135,12 @@ namespace Mono.Debugging.Client
 		/// Raised when an assembly is loaded
 		/// </summary>
 		public event EventHandler<AssemblyEventArgs> AssemblyLoaded;
-		
+
+		/// <summary>
+		/// Raised when a subprocess is started
+		/// </summary>
+		public event EventHandler<SubprocessStartedEventArgs> SubprocessStarted;
+
 		protected DebuggerSession ()
 		{
 			UseOperationThread = true;
@@ -1117,7 +1122,7 @@ namespace Mono.Debugging.Client
 			}
 		}
 		
-		internal Backtrace GetBacktrace (long processId, long threadId)
+		internal protected Backtrace GetBacktrace (long processId, long threadId)
 		{
 			lock (slock) {
 				var bt = OnGetThreadBacktrace (processId, threadId);
@@ -1299,7 +1304,12 @@ namespace Mono.Debugging.Client
 		{
 			BusyStateChanged?.Invoke (this, args);
 		}
-		
+
+		internal protected void OnSubprocessStarted (DebuggerSession session)
+		{
+			SubprocessStarted?.Invoke (this, new SubprocessStartedEventArgs { SubprocessSession = session });
+		}
+
 		/// <summary>
 		/// Tries to bind all unbound breakpoints of a source file
 		/// </summary>
@@ -1820,6 +1830,11 @@ namespace Mono.Debugging.Client
 		
 		//message may be null in which case the dialog should construct a default
 		void SetMessage (DebuggerStartInfo dsi, string message, bool listening, int attemptNumber);
+	}
+
+	public class SubprocessStartedEventArgs : EventArgs
+	{
+		public DebuggerSession SubprocessSession { get; set; }
 	}
 }
 

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSessionOptions.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSessionOptions.cs
@@ -43,5 +43,6 @@ namespace Mono.Debugging.Client
 		public bool StepOverPropertiesAndOperators { get; set; }
 		public bool ProjectAssembliesOnly { get; set; }
 		public AutomaticSourceDownload AutomaticSourceLinkDownload { get; set; }
+		public bool DebugSubprocesses { get; set; }
 	}
 }

--- a/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
@@ -191,6 +191,12 @@ namespace Mono.Debugging.Client
 				name = ""
 			};
 		}
+
+		public DebuggerSession DebuggerSession {
+			get {
+				return parentFrame?.DebuggerSession;
+			}
+		}
 		
 		/// <summary>
 		/// Gets the flags of the value

--- a/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
+++ b/Mono.Debugging/Mono.Debugging.Evaluation/ValueReference.cs
@@ -184,6 +184,17 @@ namespace Mono.Debugging.Evaluation
 			SetRawValue (path, value, options);
 		}
 
+		public object GetRawValue (EvaluationOptions options)
+		{
+			var ctx = GetContext (options);
+			return ctx.Adapter.ToRawValue (ctx, this, GetValue (ctx));
+		}
+
+		public void SetRawValue (object value, EvaluationOptions options)
+		{
+			SetRawValue (new ObjectPath (), value, options);
+		}
+
 		protected virtual void SetRawValue (ObjectPath path, object value, EvaluationOptions options)
 		{
 			var ctx = GetContext (options);


### PR DESCRIPTION
Added options and events to support subprocess debugging.
Implemented experimental subprocess debugging for the Mono
soft debugger. This is done by intercepting calls to start
the debugger and injecting the debugger agent options.
This should ideally be handled by Mono itself, and we can
propose to incorporate the required hooks to Mono, but meanwhile
we can try this hacky implementation.