### PR TITLE
Make fullModuleName protected

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs
@@ -20,7 +20,6 @@ namespace Mono.Debugging.Client
 		bool isExternalCode;
 		bool isDebuggerHidden;
 		bool hasDebugInfo;
-		protected string fullModuleName;
 		string fullTypeName;
 		
 		[NonSerialized]
@@ -39,7 +38,7 @@ namespace Mono.Debugging.Client
 			this.isExternalCode = isExternalCode;
 			this.isDebuggerHidden = isDebuggerHidden;
 			this.hasDebugInfo = hasDebugInfo;
-			this.fullModuleName = fullModuleName;
+			this.FullModuleName = fullModuleName;
 			this.fullTypeName = fullTypeName;
 		}
 
@@ -117,9 +116,7 @@ namespace Mono.Debugging.Client
 			get { return hasDebugInfo; }
 		}
 		
-		public string FullModuleName {
-			get { return fullModuleName; }
-		}
+		public string FullModuleName { get; protected set; }
 		
 		public string FullTypeName {
 			get { return fullTypeName; }

--- a/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs
@@ -20,7 +20,7 @@ namespace Mono.Debugging.Client
 		bool isExternalCode;
 		bool isDebuggerHidden;
 		bool hasDebugInfo;
-		string fullModuleName;
+		protected string fullModuleName;
 		string fullTypeName;
 		
 		[NonSerialized]


### PR DESCRIPTION
This is so we can set it from a derived class such as VSCodeStackFrame