### PR TITLE
Version check in AssemblyMirror.GetPdbBlob

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
@@ -189,7 +189,9 @@ namespace Mono.Debugger.Soft
 			if (HasFetchedPdb)
 				return pdb_blob;
 			
-			vm.CheckProtocolVersion (2, 47);
+			if (!vm.Version.AtLeast (2, 47))
+				return null;
+			
 			var blob = vm.conn.Assembly_GetPdbBlob (id);
 			if (blob != null && blob.Length > 0) {
 				pdb_blob = blob;


### PR DESCRIPTION
The current version check throws an exception. But the only function that calls this - SoftDebuggerSession.GetPdbData - does a null check. So returning null here instead of throwing an exception will make this fail gracefully instead of interrupting the whole debugging session.

This is specifically useful in situations, when we are debugging an older mono runtime and we only have MDBs and no PDBs.