### PR TITLE
Fix assembly version after converting projects to SDK style

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
@@ -10,6 +10,7 @@
     <DebugType>embedded</DebugType>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <Import Project="..\Mono.Debugging.settings" />

--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -8,6 +8,7 @@
     <DocumentationFile>bin\$(Configuration)\Mono.Debugging.Soft.xml</DocumentationFile>
     <DebugSymbols>True</DebugSymbols>
     <DebugType>embedded</DebugType>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <Import Project="..\Mono.Debugging.settings" />

--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -11,6 +11,7 @@
     <DocumentationFile>bin\$(Configuration)\Mono.Debugging.xml</DocumentationFile>
     <DebugSymbols>True</DebugSymbols>
     <DebugType>embedded</DebugType>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <Import Project="..\Mono.Debugging.settings" />


### PR DESCRIPTION
SDK style projects set the assembly version to 1.0.0.0 by
default. Classic projects use 0.0.0.0 as the assembly version.
Setting the version to 0.0.0.0 to avoid compatibility warnings.