### PR TITLE
[android][debugger] Implement support to debug after hot reload

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -483,7 +483,9 @@ namespace Mono.Debugger.Soft
 			KEEPALIVE = 14,
 			USER_BREAK = 15,
 			USER_LOG = 16,
-			CRASH = 17
+			CRASH = 17,
+			ENC_UPDATE = 18,
+			METHOD_UPDATE = 19,
 		}
 
 		enum ModifierKind {
@@ -1620,6 +1622,9 @@ namespace Mono.Debugger.Soft
 								//EventHandler.Exception (req_id, thread_id, id, loc);
 							} else if (kind == EventKind.KEEPALIVE) {
 								events [i] = new EventInfo (etype, req_id) { };
+							} else if (kind == EventKind.METHOD_UPDATE) {
+								long id = r.ReadId ();
+								events[i] = new EventInfo (etype, req_id) { ThreadId = thread_id, Id = id };
 							} else {
 								throw new NotImplementedException ("Unknown event kind: " + kind);
 							}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/EncEvents.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/EncEvents.cs
@@ -1,0 +1,20 @@
+
+namespace Mono.Debugger.Soft
+{
+	public class MethodUpdateEvent : Event
+	{
+		long id;
+		MethodMirror method;
+		internal MethodUpdateEvent (VirtualMachine vm, int req_id, long thread_id, long id) : base (EventType.MethodUpdate, vm, req_id, thread_id)
+		{
+			this.id = id;
+			method = vm.GetMethod (id);
+			method.ClearCachedLocalsDebugInfo ();
+		}
+
+		public MethodMirror GetMethod()
+		{
+			return method;
+		}
+	}
+}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/EventRequest.cs
@@ -138,5 +138,18 @@ namespace Mono.Debugger.Soft
 			if (vm != m.VirtualMachine)
 				throw new VMMismatchException ();
 		}
+
+		//Used by EnC
+		public void UpdateReqId (int id)
+		{
+			this.id = id;
+			enabled = true;
+		}
+
+		public int GetId ()
+		{
+			return id;
+		}
+
 	}
 }

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/EventType.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/EventType.cs
@@ -28,6 +28,8 @@ namespace Mono.Debugger.Soft
 		UserLog = 16,
 		// Fatal error handling
 		Crash = 17,
+		EnCUpdate = 18,
+		MethodUpdate = 19,
 		// Not part of the wire protocol
 		VMDisconnect = 99
 	}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -33,6 +33,10 @@ namespace Mono.Debugger.Soft
 		internal MethodMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
 
+		public long GetId() {
+			return id;
+		}
+
 		public string Name {
 			get {
 				if (name == null)
@@ -246,6 +250,13 @@ namespace Mono.Debugger.Soft
 					GetParameters ();
 				return ret_param;
 			}
+		}
+
+		public void ClearCachedLocalsDebugInfo ()
+		{
+			locals = null;
+			debug_info = null;
+			locations = null;
 		}
 
 		public LocalScope [] GetScopes () {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -874,6 +874,9 @@ namespace Mono.Debugger.Soft
 				case EventType.Crash:
 					l.Add (new CrashEvent (vm, req_id, thread_id, ei.Dump, ei.Hash));
 					break;
+				case EventType.MethodUpdate:
+					l.Add (new MethodUpdateEvent (vm, req_id, thread_id, id));
+					break;
 				}
 			}
 			


### PR DESCRIPTION
Related to this PR:
https://github.com/dotnet/runtime/pull/55722

- Invalidate locals_variable, debug_information and locations after apply an update.
- Get new information from runtime.
- Remove the old breakpoint with the wrong offset and create a new one with the correct offset.
