### PR TITLE
Fixed empty guid on dynamic assemblies

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ModuleMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ModuleMirror.cs
@@ -42,6 +42,8 @@ namespace Mono.Debugger.Soft
 			get {
 				if (guid == Guid.Empty) {
 					ReadInfo ();
+					if (string.IsNullOrEmpty(info.Guid))
+						return Guid.Empty;
 					guid = new Guid (info.Guid);
 				}
 				return guid;


### PR DESCRIPTION
For dynamic methods, which create an "Anonymously Hosted DynamicMethods Assembly" the Guid in ModuleInfo is string.Empty. This causes an exception when reading the Guid in the ModuleMirror because string.Empty cannot be parsed into a Guid. The right default should be Guid.Empty. This change should happen in the runtime at some point but in the meantime I need to work around it by checking explicitly. To test this, in the constructor of your class add:
`new System.Reflection.Emit.DynamicMethod("junk", typeof(void), Array.Empty<Type>());`
Then in your debugger implementation find the ManifestModule. At that
point, getting the ModuleVersionId will result in an exception.