### PR TITLE
Proper support for Catchpoint location signature

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/Catchpoint.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Catchpoint.cs
@@ -85,6 +85,17 @@ namespace Mono.Debugging.Client
 			set { includeSubclasses = value; }
 		}
 
+		/// <summary>
+		/// When an exception first happens, we are given the frame of the exception.
+		/// However by the time the user chooses "Ignore this location" in the exception dialog,
+		/// the current frame might be a different frame (the one with source code),
+		/// and not necessarily the bottom frame of the stack.
+		/// Make sure we remember the original frame where the exception happened
+		/// so that when it happens next time, we use the same frame signature to compare
+		/// against.
+		/// </summary>
+		public string CurrentLocationSignature { get; set; }
+
 		public HashSet<string> Ignored { get; private set; } = new HashSet<string> (StringComparer.Ordinal);
 
 		public bool ShouldIgnore(string type, string locationSignature)

--- a/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/StackFrame.cs
@@ -135,7 +135,16 @@ namespace Mono.Debugging.Client
 		/// </summary>
 		public string GetLocationSignature ()
 		{
-			return $"{Path.GetFileNameWithoutExtension (this.FullModuleName)}!{this.SourceLocation.MethodName}:{this.Address}";
+			string methodName = this.SourceLocation.MethodName;
+			if (methodName != null && !methodName.Contains("!")) {
+				methodName = $"{Path.GetFileName (this.FullModuleName)}!{methodName}";
+			}
+
+			if (this.Address != 0) {
+				methodName = $"{methodName}:{Address}";
+			}
+
+			return methodName;
 		}
 
 		public string GetFullStackFrameText ()


### PR DESCRIPTION
When an exception happens we didn't correctly retrieve and store the location of the exception.

We used to append the module name even if the method name already contained the module name (so we'd end up with Module!Module.dll!Class.Method). Also the Address is 0 most of the time for VSCode Debug Protocol, so no need to append it if it's zero.

Finally, store the location signature on the Catchpoint itself, so that when the user selects "Ignore exceptions at this location" we use the exact location that the debugger gave us and add it to the ignore list. Otherwise the exception can be on a different frame (the current frame that has the source code, and not the bottom frame of the stack).