### PR TITLE
Add net472 back to Mono.Debugging.Soft

### DIFF
--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Mono.Debugging\mono.debugging.snk</AssemblyOriginatorKeyFile>
     <NoWarn>1591;1573</NoWarn>


### PR DESCRIPTION
Xamarin.Android has build tasks and tests that target net472 which won't
build without multitargeting Mono.Debugging.Soft.