### PR TITLE
Fix race condition in conditional debugger tests

### DIFF
--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -998,8 +998,9 @@ namespace Mono.Debugging.Tests
 
 			InitializeTest ();
 			AddBreakpoint ("3e2e4759-f6d9-4839-98e6-4fa96b227458");
-			bp = AddBreakpoint ("eef5bea2-aaa6-4718-b26f-b35be6a6a13e");
+			bp = CreateBreakpoint ("eef5bea2-aaa6-4718-b26f-b35be6a6a13e");
 			bp.ConditionExpression = "i==2";
+			Session.Breakpoints.Add (bp);
 			StartTest ("ForLoop10");
 			CheckPosition ("eef5bea2-aaa6-4718-b26f-b35be6a6a13e");
 			val = Eval ("i");
@@ -1009,16 +1010,18 @@ namespace Mono.Debugging.Tests
 			IgnoreCorDebugger ("TODO: Conditional breakpoints with compare against string or enum is not working on CorDebugger");
 
 			InitializeTest ();
-			bp = AddBreakpoint ("033dd01d-6cb4-4e1a-b445-de6d7fa0d2a7");
+			bp = CreateBreakpoint ("033dd01d-6cb4-4e1a-b445-de6d7fa0d2a7");
 			bp.ConditionExpression = "str == \"bbb\"";
+			Session.Breakpoints.Add (bp);
 			StartTest ("ConditionalBreakpointString");
 			CheckPosition ("033dd01d-6cb4-4e1a-b445-de6d7fa0d2a7");
 			val = Eval ("str");
 			Assert.AreEqual ("\"bbb\"", val.Value);
 
 			InitializeTest ();
-			bp = AddBreakpoint ("ecf764bf-9182-48d6-adb0-0ba36e2653a7");
+			bp = CreateBreakpoint ("ecf764bf-9182-48d6-adb0-0ba36e2653a7");
 			bp.ConditionExpression = "en == BooleanEnum.False";
+			Session.Breakpoints.Add (bp);
 			StartTest ("ConitionalBreakpointEnum");
 			CheckPosition ("ecf764bf-9182-48d6-adb0-0ba36e2653a7");
 			val = Eval ("en");

--- a/UnitTests/Mono.Debugging.Tests/Shared/DebugTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/DebugTests.cs
@@ -257,11 +257,17 @@ namespace Mono.Debugging.Tests
 
 		public Breakpoint AddBreakpoint (string breakpointMarker, int offset = 0, string statement = null, ITextFile file = null)
 		{
+			var bp = CreateBreakpoint (breakpointMarker, offset, statement, file);
+			Session.Breakpoints.Add (bp);
+			return bp;
+		}
+
+		public Breakpoint CreateBreakpoint (string breakpointMarker, int offset = 0, string statement = null, ITextFile file = null)
+		{
 			file = file ?? SourceFile;
 			int col, line;
 			GetLineAndColumn (breakpointMarker, offset, statement, out line, out col, file);
 			var bp = new Breakpoint (file.Name, line, col);
-			Session.Breakpoints.Add (bp);
 			return bp;
 		}
 

--- a/UnitTests/MonoDevelop.Debugger.Tests.TestAppCore/MonoDevelop.Debugger.Tests.TestAppCore.csproj
+++ b/UnitTests/MonoDevelop.Debugger.Tests.TestAppCore/MonoDevelop.Debugger.Tests.TestAppCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
 - Conditions on the breakpoints were set after the breakpoint is added causing the conditions to be ignored depending on how fast the debugger session updates the changes.
 - Update debugger tests to use .NET 6 instead of .NET Core 3.0.