### PR TITLE
Store a Breakpoint's Full Path to make Comparison Easier

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -180,8 +180,7 @@ namespace Mono.Debugging.Client
 
 			var breakpointsToRemove = new List<BreakEvent> ();
 			foreach (var b in InternalGetBreakpoints ()) {
-				if (b is Breakpoint bp && FileNameEquals(bp.FileName, filename)
-					&&
+				if (b is Breakpoint bp && FileNameEquals(bp.FileName, filename) &&
 					(bp.OriginalLine == line || bp.Line == line) &&
 					(bp.OriginalColumn == column || bp.Column == column)) {
 					breakpointsToRemove.Add (bp);
@@ -530,7 +529,6 @@ namespace Mono.Debugging.Client
 			OnChanged ();
 		}
 
-
 		void OnBreakEventRemoved (BreakEvent be)
 		{
 			BreakEventRemoved?.Invoke (this, new BreakEventArgs (be));
@@ -541,7 +539,6 @@ namespace Mono.Debugging.Client
 			}
 			OnChanged ();
 		}
-
 
 		void OnChanged ()
 		{

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -136,7 +136,7 @@ namespace Mono.Debugging.Client
 				return false;
 
 			if (be is Breakpoint bp) {
-				bp.SetFileName (Path.GetFullPath(bp.FileName)); // TODO what happens if there is no filepath?
+				bp.SetFileName (ResolveFullPath(bp.FileName));
 			}
 
 			lock (breakpointLock) {
@@ -625,9 +625,9 @@ namespace Mono.Debugging.Client
 		{
 			System.Diagnostics.Debug.Assert (System.Threading.Monitor.IsEntered (breakpointLock), "SetBreakpoints must be called during a lock");
 
-			foreach(BreakEvent be in newBreakpoints) {
+			foreach (BreakEvent be in newBreakpoints) {
 				if (be is Breakpoint bp) {
-					bp.SetFileName (Path.GetFullPath (bp.FileName));
+					bp.SetFileName (ResolveFullPath(bp.FileName));
 				}
 			}
 

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -530,18 +530,6 @@ namespace Mono.Debugging.Client
 			OnChanged ();
 		}
 
-		void OnBreakEventsAdded (List<BreakEvent> bes)
-		{
-			foreach (BreakEvent be in bes) {
-				BreakEventAdded?.Invoke (this, new BreakEventArgs (be));
-				if (be is Breakpoint bp) {
-					BreakpointAdded?.Invoke (this, new BreakpointEventArgs (bp));
-				} else if (be is Catchpoint ce) {
-					CatchpointAdded?.Invoke (this, new CatchpointEventArgs (ce));
-				}
-			}
-			OnChanged ();
-		}
 
 		void OnBreakEventRemoved (BreakEvent be)
 		{
@@ -554,19 +542,6 @@ namespace Mono.Debugging.Client
 			OnChanged ();
 		}
 
-		void OnBreakEventsRemoved (List<BreakEvent> bes)
-		{
-			foreach (BreakEvent be in bes) {
-				BreakEventRemoved?.Invoke (this, new BreakEventArgs (be));
-				if (be is Breakpoint bp) {
-					BreakpointRemoved?.Invoke (this, new BreakpointEventArgs (bp));
-				} else if (be is Catchpoint ce) {
-					CatchpointRemoved?.Invoke (this, new CatchpointEventArgs (ce));
-				}
-			}
-
-			OnChanged ();
-		}
 
 		void OnChanged ()
 		{

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -180,7 +180,7 @@ namespace Mono.Debugging.Client
 
 			var breakpointsToRemove = new List<BreakEvent> ();
 			foreach (var b in InternalGetBreakpoints ()) {
-				if (b is Breakpoint bp && PathComparer.Compare (bp.FileName, filename) == 0
+				if (b is Breakpoint bp && FileNameEquals(bp.FileName, filename)
 					&&
 					(bp.OriginalLine == line || bp.Line == line) &&
 					(bp.OriginalColumn == column || bp.Column == column)) {
@@ -326,7 +326,7 @@ namespace Mono.Debugging.Client
 			}
 			
 			foreach (var bp in InternalGetBreakpoints ().OfType<Breakpoint> ()) {
-				if (!(bp is RunToCursorBreakpoint) && PathComparer.Compare(bp.FileName, filename) == 0)
+				if (!(bp is RunToCursorBreakpoint) && FileNameEquals(bp.FileName, filename))
 					list.Add (bp);
 			}
 			
@@ -347,7 +347,7 @@ namespace Mono.Debugging.Client
 			}
 			
 			foreach (var bp in InternalGetBreakpoints ().OfType<Breakpoint> ()) {
-				if (!(bp is RunToCursorBreakpoint) && PathComparer.Compare(bp.FileName, filename) == 0 && (bp.OriginalLine == line || bp.Line == line))
+				if (!(bp is RunToCursorBreakpoint) && FileNameEquals(bp.FileName, filename) && (bp.OriginalLine == line || bp.Line == line))
 					list.Add (bp);
 			}
 			
@@ -504,13 +504,7 @@ namespace Mono.Debugging.Client
 			if (file2 == null)
 				return false;
 
-			if (PathComparer.Compare (file1, file2) == 0)
-				return true;
-
-			var rfile1 = ResolveFullPath (file1);
-			var rfile2 = ResolveFullPath (file2);
-
-			return PathComparer.Compare (rfile1, rfile2) == 0;
+			return PathComparer.Compare (file1, file2) == 0;
 		}
 
 		internal bool EnableBreakEvent (BreakEvent be, bool enabled)


### PR DESCRIPTION
Resolving a breakpoint's full path on each comparison is less performant than getting the breakpoint's full path upon adding it to the list, and then comparing it is much easier/faster/more performance