### PR TITLE
Fix Failing Test, Add Batch Methods for Events

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/BreakEvent.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakEvent.cs
@@ -137,9 +137,10 @@ namespace Mono.Debugging.Client
 			set {
 				if (store != null && store.IsReadOnly)
 					return;
+				bool previous = enabled;
 				enabled = value;
 				if (store != null)
-					store.EnableBreakEvent (this, value);
+					store.EnableBreakEvent (this, previous, value);
 			}
 		}
 

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -506,14 +506,16 @@ namespace Mono.Debugging.Client
 			return PathComparer.Compare (file1, file2) == 0;
 		}
 
-		internal bool EnableBreakEvent (BreakEvent be, bool enabled)
+		internal bool EnableBreakEvent (BreakEvent be, bool previouslyEnabled, bool enabled)
 		{
 			if (IsReadOnly)
 				return false;
 
-			OnChanged ();
-			BreakEventEnableStatusChanged?.Invoke (this, new BreakEventArgs (be));
-			NotifyStatusChanged (be);
+			if (previouslyEnabled != enabled) {
+				OnChanged ();
+				BreakEventEnableStatusChanged?.Invoke (this, new BreakEventArgs (be));
+				NotifyStatusChanged (be);
+			}
 
 			return true;
 		}

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -255,7 +255,7 @@ namespace Mono.Debugging.Client
 					oldEvents = SetBreakpoints (breakpoints.RemoveRange (breakEvents));
 				}
 
-				List<BreakEvent> breakEventsRemoved = new List<> ();
+				List<BreakEvent> breakEventsRemoved = new List<BreakEvent> ();
 
 				foreach (var bp in breakEvents) {
 					if (oldEvents.Contains(bp)) {

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -529,6 +529,20 @@ namespace Mono.Debugging.Client
 			OnChanged ();
 		}
 
+		void OnBreakEventsAdded (List<BreakEvent> bes)
+		{
+			foreach (BreakEvent be in bes) {
+				BreakEventAdded?.Invoke (this, new BreakEventArgs (be));
+				if (be is Breakpoint bp) {
+					BreakpointAdded?.Invoke (this, new BreakpointEventArgs (bp));
+				} else if (be is Catchpoint ce) {
+					CatchpointAdded?.Invoke (this, new CatchpointEventArgs (ce));
+				}
+			}
+
+			OnChanged ();
+		}
+
 		void OnBreakEventRemoved (BreakEvent be)
 		{
 			BreakEventRemoved?.Invoke (this, new BreakEventArgs (be));
@@ -537,6 +551,20 @@ namespace Mono.Debugging.Client
 			} else if (be is Catchpoint ce) {
 				CatchpointRemoved?.Invoke (this, new CatchpointEventArgs (ce));
 			}
+			OnChanged ();
+		}
+
+		void OnBreakEventsRemoved (List<BreakEvent> bes)
+		{
+			foreach (BreakEvent be in bes) {
+				BreakEventRemoved?.Invoke (this, new BreakEventArgs (be));
+				if (be is Breakpoint bp) {
+					BreakpointRemoved?.Invoke (this, new BreakpointEventArgs (bp));
+				} else if (be is Catchpoint ce) {
+					CatchpointRemoved?.Invoke (this, new CatchpointEventArgs (ce));
+				}
+			}
+
 			OnChanged ();
 		}
 

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -255,11 +255,15 @@ namespace Mono.Debugging.Client
 					oldEvents = SetBreakpoints (breakpoints.RemoveRange (breakEvents));
 				}
 
+				List<BreakEvent> breakEventsRemoved = new List<> ();
+
 				foreach (var bp in breakEvents) {
 					if (oldEvents.Contains(bp)) {
-						OnBreakEventRemoved (bp);
+						breakEventsRemoved.Add (bp);
 					}
 				}
+
+				OnBreakEventsRemoved (breakEventsRemoved);
 			}
 		}
 
@@ -461,9 +465,7 @@ namespace Mono.Debugging.Client
 			}
 
 			// preserve behaviour by sending an event for each breakpoint that was loaded
-			foreach (var bp in loadedBreakpoints) {
-				OnBreakEventAdded (bp);
-			}
+			OnBreakEventsAdded (loadedBreakpoints);
 		}
 
 		[DllImport ("libc")]

--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -1315,7 +1315,7 @@ namespace Mono.Debugging.Tests
 			store.FileRenamed ("fileName1.cs", "fileName2.cs");
 			var bps = store.GetBreakpoints ();
 			Assert.AreEqual (1, bps.Count);
-			Assert.AreEqual (Environment.CurrentDirectory + "fileName2.cs", bps [0].FileName);
+			Assert.AreEqual (Environment.CurrentDirectory + "/fileName2.cs", bps [0].FileName);
 		}
 	}
 }

--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -1315,7 +1315,7 @@ namespace Mono.Debugging.Tests
 			store.FileRenamed ("fileName1.cs", "fileName2.cs");
 			var bps = store.GetBreakpoints ();
 			Assert.AreEqual (1, bps.Count);
-			Assert.AreEqual ("fileName2.cs", bps [0].FileName);
+			Assert.AreEqual (Environment.CurrentDirectory + "fileName2.cs", bps [0].FileName);
 		}
 	}
 }

--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -1315,7 +1315,7 @@ namespace Mono.Debugging.Tests
 			store.FileRenamed ("fileName1.cs", "fileName2.cs");
 			var bps = store.GetBreakpoints ();
 			Assert.AreEqual (1, bps.Count);
-			Assert.AreEqual (Environment.CurrentDirectory + "/fileName2.cs", bps [0].FileName);
+			Assert.AreEqual (Path.Combine(Environment.CurrentDirectory, "fileName2.cs"), bps [0].FileName);
 		}
 	}
 }


### PR DESCRIPTION
The FileRename test in BreakpointsAndSteppingTests uses a relative path to assert equality, whereas with the update to make all paths absolute, we need for the path to be absolute.

Also, Whenever there is a call to any of [these events](https://github.com/mono/debugger-libs/blob/main/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs#L594-L609), there is unnecessary work on the receiving side when there are multiple breakpoints that change.

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1476114