### PR TITLE
Make sure that the only real paths get resolved

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -135,7 +135,7 @@ namespace Mono.Debugging.Client
 			if (IsReadOnly)
 				return false;
 
-			if (be is Breakpoint bp && !string.IsNullOrEmpty (bp.FileName)) {
+			if (be is Breakpoint bp) {
 				bp.SetFileName (ResolveFullPath(bp.FileName));
 			}
 
@@ -471,8 +471,17 @@ namespace Mono.Debugging.Client
 		[DllImport ("libc")]
 		static extern IntPtr realpath (string path, IntPtr buffer);
 
+		/// <summary>
+		/// Resolves the full path of the given file
+		/// </summary>
+		/// <param name="path"></param>
+		/// <returns>The full path if a file is given, or returns the parameter if it is null or empty</returns>
 		static string ResolveFullPath (string path)
 		{
+			// If there is no path given, return the same path back
+			if (string.IsNullOrEmpty (path))
+				return path;
+
 			if (IsWindows)
 				return Path.GetFullPath (path);
 
@@ -658,7 +667,7 @@ namespace Mono.Debugging.Client
 			System.Diagnostics.Debug.Assert (System.Threading.Monitor.IsEntered (breakpointLock), "SetBreakpoints must be called during a lock");
 
 			foreach (BreakEvent be in newBreakpoints) {
-				if (be is Breakpoint bp && !string.IsNullOrEmpty(bp.FileName)) {
+				if (be is Breakpoint bp) {
 					bp.SetFileName (ResolveFullPath(bp.FileName));
 				}
 			}

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -135,7 +135,7 @@ namespace Mono.Debugging.Client
 			if (IsReadOnly)
 				return false;
 
-			if (be is Breakpoint bp) {
+			if (be is Breakpoint bp && !string.IsNullOrEmpty (bp.FileName)) {
 				bp.SetFileName (ResolveFullPath(bp.FileName));
 			}
 
@@ -658,7 +658,7 @@ namespace Mono.Debugging.Client
 			System.Diagnostics.Debug.Assert (System.Threading.Monitor.IsEntered (breakpointLock), "SetBreakpoints must be called during a lock");
 
 			foreach (BreakEvent be in newBreakpoints) {
-				if (be is Breakpoint bp) {
+				if (be is Breakpoint bp && !string.IsNullOrEmpty(bp.FileName)) {
 					bp.SetFileName (ResolveFullPath(bp.FileName));
 				}
 			}

--- a/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
+++ b/UnitTests/Mono.Debugging.Tests/Shared/BreakpointsAndSteppingTests.cs
@@ -1317,5 +1317,23 @@ namespace Mono.Debugging.Tests
 			Assert.AreEqual (1, bps.Count);
 			Assert.AreEqual (Path.Combine(Environment.CurrentDirectory, "fileName2.cs"), bps [0].FileName);
 		}
+
+		[Test]
+		public void NullFileName ()
+		{
+			var store = new BreakpointStore ();
+			store.Add (new Breakpoint (null, 10));
+			var bps = store.GetBreakpoints ();
+			Assert.AreEqual (1, bps.Count);
+		}
+
+		[Test]
+		public void EmptyFileName ()
+		{
+			var store = new BreakpointStore ();
+			store.Add (new Breakpoint ("", 10));
+			var bps = store.GetBreakpoints ();
+			Assert.AreEqual (1, bps.Count);
+		}
 	}
 }


### PR DESCRIPTION
We were encountering an exception with Functional Breakpoints, which have no filepath, because ResolveFullPath was throwing