### PR TITLE
Fix fatal null reference exception in StartConnection

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -156,7 +156,7 @@ namespace Mono.Debugging.Soft
 				} catch (Exception ex) {
 					attemptNumber++;
 					if (!ShouldRetryConnection (ex, attemptNumber)
-						|| !startArgs.ConnectionProvider.ShouldRetryConnection (ex)
+						|| startArgs?.ConnectionProvider?.ShouldRetryConnection (ex) == false
 						|| attemptNumber == maxAttempts
 						|| HasExited) {
 						OnConnectionError (ex);


### PR DESCRIPTION
When the iOS simulator is stopped immediately after it starts up
the debugger would crash the IDE with a fatal unhandled null
reference exception in StartConnection.

An unhandled exception has occurred. Terminating Visual Studio? True
System.NullReferenceException: Object reference not set to an
instance of an object.
   at Mono.Debugging.Soft.SoftDebuggerSession.<>c__DisplayClass47_0
.<StartConnection>b__0(IAsyncResult ar) in Mono.Debugging.Soft/
SoftDebuggerSession.cs:line 158

On stopping the simulator the startArgs field is set to null in
EndLaunch. This was not handled in the callback used in
StartConnection and would cause the fatal exception. Handle a null
startsArgs in the callback when checking if a retry is required.

Fixes VSTS #1506514 - VS crashes when start debugging Xamarin.Forms
(target iOS) project using iPhone simulator