### PR TITLE
Protect from errors related to cancelling debugger connection

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
@@ -338,6 +338,8 @@ namespace Mono.Debugger.Soft
 
 		public static void CancelConnection (IAsyncResult asyncResult)
 		{
+			//AsyncState could be null if the debugger incoming connection doesn't happen, so there's no socket between debugger and debuggee
+			//This could occur if the debugger session started but the connection to the app failed at some point
 			((Socket)asyncResult.AsyncState)?.Close ();
 		}
 		

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
@@ -338,7 +338,7 @@ namespace Mono.Debugger.Soft
 
 		public static void CancelConnection (IAsyncResult asyncResult)
 		{
-			((Socket)asyncResult.AsyncState).Close ();
+			((Socket)asyncResult.AsyncState)?.Close ();
 		}
 		
 		public static VirtualMachine Connect (Connection transport, StreamReader standardOutput, StreamReader standardError)

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -386,11 +386,15 @@ namespace Mono.Debugging.Soft
 		{
 			HideConnectionDialog ();
 			if (connection != null) {
-				if (startArgs != null && startArgs.ConnectionProvider != null) {
-					startArgs.ConnectionProvider.CancelConnect (connection);
-					startArgs = null;
-				} else {
-					VirtualMachineManager.CancelConnection (connection);
+				try {
+					if (startArgs != null && startArgs.ConnectionProvider != null) {
+						startArgs.ConnectionProvider.CancelConnect(connection);
+						startArgs = null;
+					} else {
+						VirtualMachineManager.CancelConnection(connection);
+					}
+				} catch(Exception e) {
+					DebuggerLoggingService.LogError("Unhandled error canceling the debugger connection", e);
 				}
 				connection = null;
 			}


### PR DESCRIPTION
If any unexpected error occurs when ending the debugger launch session, some important things may not happen like invoking the TargetExited event, which could cause the debugger session to hang.
For this reason, we should handle any exception happening around it and report it accordingly
One reason for this problem to reproduce is when the debugger session launches but the connection with the app is not established, so the session will never end and potentially hang under any UI interaction