### PR TITLE
Support new hotreload features and support line changes

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionCecil)" PrivateAssets="all" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0" />
   </ItemGroup>
 
 </Project>

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -515,7 +515,7 @@ namespace Mono.Debugger.Soft
 			INVOKE_METHODS = 13,
 			START_BUFFERING = 14,
 			STOP_BUFFERING = 15,
-			GET_ENC_CAPABILITIES = 20
+			GET_ENC_CAPABILITIES = 21
 		}
 
 		enum CmdEvent {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -514,7 +514,8 @@ namespace Mono.Debugger.Soft
 			GET_TYPES = 12,
 			INVOKE_METHODS = 13,
 			START_BUFFERING = 14,
-			STOP_BUFFERING = 15
+			STOP_BUFFERING = 15,
+			GET_ENC_CAPABILITIES = 20
 		}
 
 		enum CmdEvent {
@@ -1959,6 +1960,12 @@ namespace Mono.Debugger.Soft
 			} else {
 				return r.ReadValue ();
 			}
+		}
+
+		internal string VM_EnCCapabilities ()
+		{
+			PacketReader r = SendReceive (CommandSet.VM, (int)CmdVM.GET_ENC_CAPABILITIES, new PacketWriter ());
+			return r.ReadString ();
 		}
 
 		internal delegate void InvokeMethodCallback (ValueImpl v, ValueImpl exc, ValueImpl out_this, ValueImpl[] out_args, ErrorCode error, object state);

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/EncEvents.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/EncEvents.cs
@@ -9,7 +9,6 @@ namespace Mono.Debugger.Soft
 		{
 			this.id = id;
 			method = vm.GetMethod (id);
-			method.ClearCachedLocalsDebugInfo ();
 		}
 
 		public MethodMirror GetMethod()

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Location.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Location.cs
@@ -48,7 +48,10 @@ namespace Mono.Debugger.Soft
 			get {
 				return line_number;
 			}
-	    }
+			set {
+				this.line_number = value;
+			}
+		}
 
 		// Since protocol version 2.19, 0 in earlier protocol versions
 		public int ColumnNumber {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -434,7 +434,10 @@ namespace Mono.Debugger.Soft
 
 		// FIXME: Sync this with Type
 		public MethodMirror GetMethod (string name) {
-			return methods.FirstOrDefault (m => m.Name == name);
+			foreach (var m in GetMethods ())
+				if (m.Name == name)
+					return m;
+			return null;
 		}
 
 		public FieldInfoMirror[] GetFields () {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -424,7 +424,7 @@ namespace Mono.Debugger.Soft
 			}
 			return methods.ToArray();
 		}
-		public void FindOrAddMethod(MethodMirror method)
+		public void AddMethodIfNotExist (MethodMirror method)
 		{
 			if (!Array.Exists(GetMethods (), (m => m.GetId() == method.GetId()))) {
 				//is EnC

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -417,7 +417,7 @@ namespace Mono.Debugger.Soft
 		public MethodMirror[] GetMethods () {
 			if (methods == null) {
 				long[] ids = vm.conn.Type_GetMethods (id);
-				methods = new List<MethodMirror>();
+				methods = new List<MethodMirror>(ids.Length);
 				for (int i = 0; i < ids.Length; ++i) {
 					methods.Add(vm.GetMethod (ids [i]));
 				}
@@ -934,8 +934,7 @@ namespace Mono.Debugger.Soft
 
 	public class SourceUpdate
 	{
-
-		public List<Tuple<int, int>> LineUpdates { get; }
+		public List<Tuple<int, int>> LineUpdates { get; } //Tuple<oldLine, newLine>
 		public string FileName { get; }
 
 		public SourceUpdate (string fileName)

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -793,7 +793,14 @@ namespace Mono.Debugger.Soft
 			if (!conn.Version.AtLeast (major, minor))
 				throw new NotSupportedException ("This request is not supported by the protocol version implemented by the debuggee.");
 		}
-    }
+
+		public string GetEnCCapabilities ()
+		{
+			if (conn.Version.AtLeast (2, 61))
+				return conn.VM_EnCCapabilities ();
+			return "Baseline";
+		}
+	}
 
 	class EventHandler : MarshalByRefObject, IEventHandler
 	{		

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2421,7 +2421,7 @@ namespace Mono.Debugging.Soft
 			foreach (var method in methods) //add new methods to type
 			{
 				method.GetMethod ().ClearCachedLocalsDebugInfo ();
-				method.GetMethod ().DeclaringType.FindOrAddMethod (method.GetMethod ());
+				method.GetMethod ().DeclaringType.AddMethodIfNotExist (method.GetMethod ());
 			}
 			foreach (var breakpoint in breakpoints) {
 				Breakpoint bp = ((Breakpoint)breakpoint.Value.BreakEvent);

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -48,6 +48,7 @@ using Mono.Debugging.Client;
 using Mono.Debugging.Evaluation;
 
 using StackFrame = Mono.Debugger.Soft.StackFrame;
+using System.Collections.Immutable;
 
 namespace Mono.Debugging.Soft
 {
@@ -76,6 +77,7 @@ namespace Mono.Debugging.Soft
 		bool loggedSymlinkedRuntimesBug;
 		SoftDebuggerStartArgs startArgs;
 		List<string> userAssemblyNames;
+		List<SourceUpdate> sourceUpdates;
 		ThreadInfo[] current_threads;
 		string remoteProcessName;
 		long currentAddress = -1;
@@ -99,6 +101,7 @@ namespace Mono.Debugging.Soft
 			Adaptor = CreateSoftDebuggerAdaptor ();
 			Adaptor.BusyStateChanged += (sender, e) => SetBusyState (e);
 			Adaptor.DebuggerSession = this;
+			sourceUpdates = new List<SourceUpdate> ();
 		}
 
 		protected virtual SoftDebuggerAdaptor CreateSoftDebuggerAdaptor ()
@@ -1193,12 +1196,12 @@ namespace Mono.Debugging.Soft
 					found = true;
 					breakInfo.SetStatus (BreakEventStatus.Bound, null);
 				}
-
 				lock (pending_bes) {
 					pending_bes.Add (breakInfo);
 				}
 
 				if (!found) {
+					breakInfo.Breakpoint = breakpoint;
 					if (insideLoadedRange)
 						breakInfo.SetStatus (BreakEventStatus.Invalid, null);
 					else
@@ -2415,15 +2418,33 @@ namespace Mono.Debugging.Soft
 
 		void HandleMethodUpdateEvents(MethodUpdateEvent[] methods)
 		{
-			foreach (var method in methods)
+			foreach (var method in methods) //add new methods to type
 			{
-				foreach (var bp in breakpoints) {
-					if (bp.Value.Location.Method.GetId() == method.GetMethod().GetId())
-					{
-						bool dummy = false;
-						var l = FindLocationByMethod (bp.Value.Location.Method, bp.Value.Location.SourceFile, bp.Value.Location.LineNumber, bp.Value.Location.ColumnNumber, ref dummy);
-						bp.Value.Location = l;
-						UpdateBreakpoint ((Breakpoint)bp.Value.BreakEvent, bp.Value);
+				method.GetMethod ().ClearCachedLocalsDebugInfo ();
+				method.GetMethod ().DeclaringType.FindOrAddMethod (method.GetMethod ());
+			}
+			foreach (var breakpoint in breakpoints) {
+				Breakpoint bp = ((Breakpoint)breakpoint.Value.BreakEvent);
+				if (bp.UpdatedByEnC) {
+					bool dummy = false;
+					var l = FindLocationByMethod (breakpoint.Value.Location.Method, bp.FileName, bp.Line, bp.Column, ref dummy);
+					if (l != null) {
+						breakpoint.Value.Location = l;
+						UpdateBreakpoint (bp, breakpoint.Value);
+						bp.UpdatedByEnC = false;
+					}
+				}
+			}
+			foreach (var bp in pending_bes) {
+				if (bp.Status != BreakEventStatus.Bound) {
+					foreach (var location in FindLocationsByFile (bp.Breakpoint.FileName, bp.Breakpoint.Line, bp.Breakpoint.Column, out _, out bool insideLoadedRange)) {
+						OnDebuggerOutput (false, string.Format ("Resolved pending breakpoint at '{0}:{1},{2}' to {3} [0x{4:x5}].\n",
+																bp.Breakpoint.FileName, bp.Breakpoint.Line, bp.Breakpoint.Column,
+																GetPrettyMethodName (location.Method), location.ILOffset));
+
+						bp.Location = location;
+						InsertBreakpoint (bp.Breakpoint, bp);
+						bp.SetStatus (BreakEventStatus.Bound, null);
 					}
 				}
 			}
@@ -3342,6 +3363,14 @@ namespace Mono.Debugging.Soft
 			return lines.ToArray ();
 		}
 
+		public void AddSourceUpdate (string fileName)
+		{
+			sourceUpdates.Add (new SourceUpdate(fileName));
+		}
+		public void AddLineUpdate (int oldLine, int newLine)
+		{
+			sourceUpdates.Last().LineUpdates.Add (new Tuple<int, int>(oldLine, newLine));
+		}
 		public void ApplyChanges (ModuleMirror module, byte[] metadataDelta, byte[] ilDelta, byte[] pdbDelta = null)
 		{
 			var rootDomain = VirtualMachine.RootDomain;
@@ -3353,7 +3382,22 @@ namespace Mono.Debugging.Soft
 			else
 				pdbArray = rootDomain.CreateByteArray (pdbDelta);
 
+			module.Assembly.ApplyChanges_DebugInformation (metadataDelta, pdbDelta);
 			module.ApplyChanges (metadataArray, ilArray, pdbArray);
+			foreach (var sourceUpdate in sourceUpdates)
+			{
+				var types = VirtualMachine.GetTypesForSourceFile (sourceUpdate.FileName, false);
+				foreach (var type in types)
+				{
+					type.ApplySourceChanges (sourceUpdate);
+				}
+			}
+			sourceUpdates.Clear ();
+		}
+
+		public string GetEnCCapabilities()
+		{
+			return vm.GetEnCCapabilities ();
 		}
 		static string EscapeString (string text)
 		{

--- a/Mono.Debugging/Mono.Debugging.Client/BreakEventInfo.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakEventInfo.cs
@@ -52,6 +52,8 @@ namespace Mono.Debugging.Client
 		/// </summary>
 		public BreakEventStatus Status { get; private set; }
 
+		public Breakpoint Breakpoint { get; set; }
+
 		/// <summary>
 		/// Gets a description of the status
 		/// </summary>

--- a/Mono.Debugging/Mono.Debugging.Client/Breakpoint.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Breakpoint.cs
@@ -117,7 +117,9 @@ namespace Mono.Debugging.Client
 			ResetAdjustedColumn ();
 			column = newColumn;
 		}
-		
+
+		public bool UpdatedByEnC { get; set; }
+
 		public void SetLine (int newLine)
 		{
 			ResetAdjustedLine ();


### PR DESCRIPTION
About HotReload now we can do in an android app and the debug will continue working:

1) add lines before the breakpoint and the breakpoint will continue working
2) remove lines before the breakpoint and the breakpoint will continue working
3) add new static methods
4) add new static fields
5) add new classes

Also we check what is supported by runtime to make it possible from debugger.

Related to:
https://github.com/xamarin/debugger-vs/pull/287
https://github.com/dotnet/runtime/pull/70697