### PR TITLE
Provide listed assembly in process for moduleview

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2262,19 +2262,17 @@ namespace Mono.Debugging.Soft
 
 		private void HandleAssemblyLoaded (AssemblyMirror asm)
 		{
-			var symbolStatus = string.Empty;
-			var assemblyName = string.Empty;
-			var hasSymbol = false;
 			var name = asm.GetName ();
 			var assemblyObject = asm.GetAssemblyObject ();
-			if (!asm.IsDynamic) {
+			bool isDynamic = asm.IsDynamic;
+			string assemblyName;
+			bool hasSymbol;
+			if (!isDynamic) {
 				var metaData = asm.GetMetadata ();
-				symbolStatus = metaData.MainModule.HasSymbols == true ? "Symbol loaded" : "Skipped loading symbols";
 				assemblyName = metaData.MainModule.Name;
 				hasSymbol = metaData.MainModule.HasSymbols;
 			} else {
-				symbolStatus = "Skipped loading symbol (dynamic)";
-				assemblyName = "Dynamic assembly";
+				assemblyName = string.Empty;
 				hasSymbol = false;
 			}
 			var assembly = new Assembly (
@@ -2282,16 +2280,18 @@ namespace Mono.Debugging.Soft
 					asm.Location,
 					true,
 					hasSymbol,
-					symbolStatus,
-					"",
+					string.Empty,
+					string.Empty,
 					-1,
 					name.Version.Major.ToString (),
 					// TODO: module time stamp
-					"",
+					string.Empty,
 					assemblyObject.Address.ToString (),
 					string.Format ("[{0}]{1}", asm.VirtualMachine.TargetProcess.Id, asm.VirtualMachine.TargetProcess.ProcessName),
 					asm.Domain.FriendlyName,
-					asm.VirtualMachine.TargetProcess.Id
+					asm.VirtualMachine.TargetProcess.Id,
+					hasSymbol,
+					isDynamic
 			);
 
 			OnAssemblyLoaded (assembly);

--- a/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
@@ -44,7 +44,7 @@ namespace Mono.Debugging.Client
 			UserCode = userCode;
 			ProcessId = processId;
 			IsDynamic = isDynamic;
-			HasSymbol = hasSymbol;
+			HasSymbols = hasSymbol;
 		}
 		public Assembly (string path)
 		{
@@ -77,7 +77,7 @@ namespace Mono.Debugging.Client
 
 		public long? ProcessId { get; private set; } = -1;
 
-		public bool HasSymbol { get; private set; }
+		public bool HasSymbols { get; private set; }
 
 		public bool IsDynamic { get; private set; }
 	}

--- a/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
@@ -1,0 +1,79 @@
+//
+// Assembly.cs
+//
+// Author:
+//       Jonathan Chang <t-jochang@microsoft.com>
+//
+// Copyright (c) 2022 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace Mono.Debugging.Client
+{
+	public class Assembly
+	{
+		public Assembly (string name, string path, bool optimized, bool userCode, string symbolStatus, string symbolFile, int? order, string version, string timestamp, string address, string process, string appdomain, long? processId)
+		{
+			Name = name;
+			Path = path;
+			Optimized = optimized;
+			SymbolStatus = symbolStatus;
+			SymbolFile = symbolFile;
+			Order = order.GetValueOrDefault (-1);
+			TimeStamp = timestamp;
+			Address = address;
+			Process = process;
+			AppDomain = appdomain;
+			Version = version;
+			UserCode = userCode;
+			ProcessId = processId;
+
+		}
+		public Assembly (string path)
+		{
+			Path = path;
+		}
+
+		public string Name { get; private set; }
+
+		public string Path { get; private set; }
+
+		public bool Optimized { get; private set; }
+
+		public bool UserCode { get; private set; }
+
+		public string SymbolStatus { get; private set; }
+
+		public string SymbolFile { get; private set; }
+
+		public int Order { get; private set; } = -1;
+
+		public string Version { get; private set; }
+
+		public string TimeStamp { get; private set; }
+
+		public string Address { get; private set; }
+
+		public string Process { get; private set; }
+
+		public string AppDomain { get; private set; }
+
+		public long? ProcessId { get; private set; } = -1;
+	}
+}

--- a/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
@@ -28,6 +28,39 @@ namespace Mono.Debugging.Client
 {
 	public class Assembly
 	{
+		/// <summary>
+		/// Represent the assembly loaded during the debugging session. This dataclass will be used in the modules pad view for display. 
+		/// </summary>
+		/// <param name="name"></param>
+		/// String represent the name of the assembly.
+		/// <param name="path"></param>
+		/// String represent the local path of the assembly is loaded from.
+		/// <param name="optimized"></param>
+		/// Boolean shows if the assembly has been optimized, true if the assembly is optimized.
+		/// <param name="userCode"></param>
+		/// Boolean show if the assembly is considered 'user code' by a debugger that supports 'Just My Code'.True if it's considered.
+		/// <param name="symbolStatus"></param>
+		/// String represent the Description on if symbols were found for the assembly (ex: 'Symbols Loaded', 'Symbols not found', etc.
+		/// <param name="symbolFile"></param>
+		/// String represent the Logical full path to the symbol file. The exact definition is implementation defined.
+		/// <param name="order"></param>
+		/// Integer indicating the order in which the assembly was loaded.
+		/// <param name="version"></param>
+		/// String represent the version of assembly.
+		/// <param name="timestamp"></param>
+		/// String represent the time when the assembly was built in the units of UNIX timestamp formatted as a 64-bit unsigned decimal number in a string.
+		/// <param name="address"></param>
+		/// String resent the Address where the assembly was loaded as a 64-bit unsigned decimal number.
+		/// <param name="process"></param>
+		/// String represent the process name and process ID the assembly is loaded. 
+		/// <param name="appdomain"></param>
+		/// String indicates the name of the AppDomain where the assembly is loaded.
+		/// <param name="processId"></param>
+		/// Long represent the process ID the assembly is loaded. 
+		/// <param name="hasSymbol"></param
+		/// Bool value indicate if the assembly has symbol file. Mainly use for mono project.
+		/// <param name="isDynamic"></param>
+		/// Bool value indicate if the assembly is a dynamic. Mainly use for mono project. 
 		public Assembly (string name, string path, bool optimized, bool userCode, string symbolStatus, string symbolFile, int? order, string version, string timestamp, string address, string process, string appdomain, long? processId, bool hasSymbol = false, bool isDynamic = false)
 		{
 			Name = name;

--- a/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
@@ -26,41 +26,11 @@
 using System;
 namespace Mono.Debugging.Client
 {
+	/// <summary>
+	/// Represents the assembly loaded during the debugging session.
+	/// </summary>
 	public class Assembly
 	{
-		/// <summary>
-		/// Represent the assembly loaded during the debugging session. This dataclass will be used in the modules pad view for display. 
-		/// </summary>
-		/// <param name="name"></param>
-		/// String represent the name of the assembly.
-		/// <param name="path"></param>
-		/// String represent the local path of the assembly is loaded from.
-		/// <param name="optimized"></param>
-		/// Boolean shows if the assembly has been optimized, true if the assembly is optimized.
-		/// <param name="userCode"></param>
-		/// Boolean show if the assembly is considered 'user code' by a debugger that supports 'Just My Code'.True if it's considered.
-		/// <param name="symbolStatus"></param>
-		/// String represent the Description on if symbols were found for the assembly (ex: 'Symbols Loaded', 'Symbols not found', etc.
-		/// <param name="symbolFile"></param>
-		/// String represent the Logical full path to the symbol file. The exact definition is implementation defined.
-		/// <param name="order"></param>
-		/// Integer indicating the order in which the assembly was loaded.
-		/// <param name="version"></param>
-		/// String represent the version of assembly.
-		/// <param name="timestamp"></param>
-		/// String represent the time when the assembly was built in the units of UNIX timestamp formatted as a 64-bit unsigned decimal number in a string.
-		/// <param name="address"></param>
-		/// String resent the Address where the assembly was loaded as a 64-bit unsigned decimal number.
-		/// <param name="process"></param>
-		/// String represent the process name and process ID the assembly is loaded. 
-		/// <param name="appdomain"></param>
-		/// String indicates the name of the AppDomain where the assembly is loaded.
-		/// <param name="processId"></param>
-		/// Long represent the process ID the assembly is loaded. 
-		/// <param name="hasSymbol"></param
-		/// Bool value indicate if the assembly has symbol file. Mainly use for mono project.
-		/// <param name="isDynamic"></param>
-		/// Bool value indicate if the assembly is a dynamic. Mainly use for mono project. 
 		public Assembly (string name, string path, bool optimized, bool userCode, string symbolStatus, string symbolFile, int? order, string version, string timestamp, string address, string process, string appdomain, long? processId, bool hasSymbol = false, bool isDynamic = false)
 		{
 			Name = name;
@@ -79,39 +49,85 @@ namespace Mono.Debugging.Client
 			IsDynamic = isDynamic;
 			HasSymbols = hasSymbol;
 		}
+
 		public Assembly (string path)
 		{
 			Path = path;
 		}
 
+		/// <summary>
+		/// Represents the name of the assembly.
+		/// </summary>
 		public string Name { get; private set; }
 
+		/// <summary>
+		/// Represents the local path of the assembly is loaded from.
+		/// </summary>
 		public string Path { get; private set; }
 
+		/// <summary>
+		/// Shows if the assembly has been optimized, true if the assembly is optimized.
+		/// </summary>
 		public bool Optimized { get; private set; }
 
+		/// <summary>
+		/// Shows if the assembly is considered 'user code' by a debugger that supports 'Just My Code'.True if it's considered.
+		/// </summary>
 		public bool UserCode { get; private set; }
 
+		/// <summary>
+		/// Represents the Description on if symbols were found for the assembly (ex: 'Symbols Loaded', 'Symbols not found', etc.
+		/// </summary>
 		public string SymbolStatus { get; private set; }
 
+		/// <summary>
+		/// Represents the Logical full path to the symbol file. The exact definition is implementation defined.
+		/// </summary>
 		public string SymbolFile { get; private set; }
 
+		/// <summary>
+		/// Represents the order in which the assembly was loaded.
+		/// </summary>
 		public int Order { get; private set; } = -1;
 
+		/// <summary>
+		/// Represents the version of assembly.
+		/// </summary>
 		public string Version { get; private set; }
 
+		/// <summary>
+		/// Represents the time when the assembly was built in the units of UNIX timestamp formatted as a 64-bit unsigned decimal number in a string.
+		/// </summary>
 		public string TimeStamp { get; private set; }
 
+		/// <summary>
+		/// Represents the Address where the assembly was loaded as a 64-bit unsigned decimal number.
+		/// </summary>
 		public string Address { get; private set; }
 
+		/// <summary>
+		/// Represent the process name and process ID the assembly is loaded. 
+		/// </summary>
 		public string Process { get; private set; }
 
+		/// <summary>
+		/// Represent the name of the AppDomain where the assembly is loaded.
+		/// </summary>
 		public string AppDomain { get; private set; }
 
+		/// <summary>
+		/// Represent the process ID the assembly is loaded. 
+		/// </summary>
 		public long? ProcessId { get; private set; } = -1;
 
+		/// <summary>
+		/// Indicates if the assembly has symbol file. Mainly use for mono project.
+		/// </summary>
 		public bool HasSymbols { get; private set; }
 
+		/// <summary>
+		/// Indicate if the assembly is a dynamic. Mainly use for mono project. 
+		/// </summary>
 		public bool IsDynamic { get; private set; }
 	}
 }

--- a/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/Assembly.cs
@@ -28,7 +28,7 @@ namespace Mono.Debugging.Client
 {
 	public class Assembly
 	{
-		public Assembly (string name, string path, bool optimized, bool userCode, string symbolStatus, string symbolFile, int? order, string version, string timestamp, string address, string process, string appdomain, long? processId)
+		public Assembly (string name, string path, bool optimized, bool userCode, string symbolStatus, string symbolFile, int? order, string version, string timestamp, string address, string process, string appdomain, long? processId, bool hasSymbol = false, bool isDynamic = false)
 		{
 			Name = name;
 			Path = path;
@@ -43,7 +43,8 @@ namespace Mono.Debugging.Client
 			Version = version;
 			UserCode = userCode;
 			ProcessId = processId;
-
+			IsDynamic = isDynamic;
+			HasSymbol = hasSymbol;
 		}
 		public Assembly (string path)
 		{
@@ -75,5 +76,9 @@ namespace Mono.Debugging.Client
 		public string AppDomain { get; private set; }
 
 		public long? ProcessId { get; private set; } = -1;
+
+		public bool HasSymbol { get; private set; }
+
+		public bool IsDynamic { get; private set; }
 	}
 }

--- a/Mono.Debugging/Mono.Debugging.Client/AssemblyEventArgs.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/AssemblyEventArgs.cs
@@ -30,12 +30,23 @@ namespace Mono.Debugging.Client
 {
 	public class AssemblyEventArgs : EventArgs
 	{
+		public AssemblyEventArgs (Assembly assembly)
+		{
+			Location = assembly.Path;
+			Assembly = assembly;
+		}
+
 		public AssemblyEventArgs (string location)
 		{
 			Location = location;
+			Assembly = new Assembly (location);
 		}
 
 		public string Location {
+			get; private set;
+		}
+
+		public Assembly Assembly {
 			get; private set;
 		}
 	}

--- a/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
@@ -78,5 +78,13 @@ namespace Mono.Debugging.Client
 		{
 			return session.GetThreads (id);
 		}
+
+		/// <summary>
+		/// Gets assemblies from the debugger session that matches the process ID.
+		/// </summary>
+		public Assembly[] GetAssemblies ()
+		{
+			return session.GetAssemblies (id);
+		}
 	}
 }


### PR DESCRIPTION
1. Add assembly data structure,
2. Store assemblies that were loaded in the debugger session.
3. Allow the process to access loaded assemblies in the debugger session.
4. Allow Debbuggng service to access the loaded assemblies to create modules pad
