### PR TITLE
[compliance] Updated NewtonSoft.Json to 13.0.1

### DIFF
--- a/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionCecil)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(NuGetVersionRoslyn)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(NuGetVersionRoslyn)" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Mono.Unix" Version="7.0.0-final.1.21369.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Component Governance in debugger-vs is flagging us for having an indirect reference to a vulnerable version of NewtonSoft.Json.

Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of StackOverFlow exception (SOE) whenever nested expressions are being processed. Exploiting this vulnerability results in Denial Of Service (DoS), and it is exploitable when an attacker sends 5 requests that cause SOE in time frame of 5 minutes.

More information: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113466/alert/7088785?typeId=4611249
Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1559264