### PR TITLE
Set options before Dispatch

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -410,9 +410,10 @@ namespace Mono.Debugging.Client
 			if (options == null)
 				throw new ArgumentNullException (nameof (options));
 
+			Interlocked.Exchange (ref this.options, options);
+
 			Dispatch (delegate {
 				try {
-					this.options = options;
 					OnRunning ();
 					OnRun (startInfo);
 				} catch (Exception ex) {
@@ -444,9 +445,10 @@ namespace Mono.Debugging.Client
 			if (options == null)
 				throw new ArgumentNullException (nameof (options));
 
+			Interlocked.Exchange (ref this.options, options);
+
 			Dispatch (delegate {
 				try {
-					this.options = options;
 					OnRunning ();
 					OnAttachToProcess (proc);
 					attached = true;


### PR DESCRIPTION
This is a feedback fix in response to https://github.com/mono/debugger-libs/pull/371#discussion_r925712902

cc @slluis @Therzok 