### PR TITLE
Fix libc.dll not found exception causing breakpoints not to be bound

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -491,8 +491,8 @@ namespace Mono.Debugging.Client
 			catch
 			{
 				result = Path.GetFullPath(path);
-            }
-            return result;
+			}
+			return result;
 		}
 
 		public static bool FileNameEquals (string file1, string file2)

--- a/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/BreakpointStore.cs
@@ -481,11 +481,18 @@ namespace Mono.Debugging.Client
 		{
 			// If there is no path given, return the same path back
 			if (string.IsNullOrEmpty(path))
-					return path;
-			var result = realpath(path, IntPtr.Zero);
-			if (result == null)
-					return Path.GetFullPath(path);
-			return result;
+				return path;
+
+			string result = null;
+			try
+			{
+				result = realpath(path, IntPtr.Zero);
+			}
+			catch
+			{
+				result = Path.GetFullPath(path);
+            }
+            return result;
 		}
 
 		public static bool FileNameEquals (string file1, string file2)


### PR DESCRIPTION
Not finding libc.dll causes an exception to fire and for us not to fall back to the Path.GetFullPath method. 

This fixes it :)

System.DllNotFoundException
  HResult=0x80131524
  Message=Unable to load DLL 'libc': The specified module could not be found. (Exception from HRESULT: 0x8007007E)
  Source=Mono.Debugging
  StackTrace:
   at Mono.Debugging.Client.BreakpointStore.realpath(String path, IntPtr buffer)
   at Mono.Debugging.Client.BreakpointStore.ResolveFullPath(String path) in D:\Repos\xamarinDebugVs\external\debugger-libs\Mono.Debugging\Mono.Debugging.Client\BreakpointStore.cs:line 489

  This exception was originally thrown at this call stack:
    Mono.Debugging.Client.BreakpointStore.ResolveFullPath(string) in BreakpointStore.cs