### PR TITLE
Trying to avoid getting metadata of all the assemblies loaded from runtime

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2268,9 +2268,8 @@ namespace Mono.Debugging.Soft
 			string assemblyName;
 			bool hasSymbol;
 			if (!isDynamic) {
-				var metaData = asm?.GetMetadata() ?? null;
-				assemblyName = metaData?.MainModule?.Name ?? string.Empty;
-				hasSymbol = metaData?.MainModule?.HasSymbols ?? false;
+				assemblyName = name.Name;
+				hasSymbol = asm.HasDebugInfo;
 			} else {
 				assemblyName = string.Empty;
 				hasSymbol = false;


### PR DESCRIPTION
This should avoid sending all metadata information over the wire which may impact the performance of debugging a maui app.
Also this should avoid crashing while debugging using meadow.