### PR TITLE
Move symbol server support from debugger-vs and complete the implementation

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionCecil)" PrivateAssets="all" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0" />
+    <PackageReference Include="Microsoft.SymbolStore" Version="1.0.411401" />
+    <PackageReference Include="Microsoft.FileFormats" Version="1.0.411401" />
   </ItemGroup>
 
 </Project>

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
@@ -6,6 +6,7 @@ using System.IO;
 
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using Microsoft.FileFormats.PE;
 
 #if ENABLE_CECIL
 using Mono.Cecil;
@@ -158,7 +159,11 @@ namespace Mono.Debugger.Soft
 				return meta = Mono.Cecil.AssemblyDefinition.ReadAssembly (ms);
 		}
 #endif
-
+		public bool GetPdbInfo (out int age, out Guid guid, out string pdbPath, out bool isPortableCodeView, out PdbChecksum[] pdbChecksums)
+		{
+			return vm.conn.Assembly_GetDebugDirectoryInformation (id, out age, out guid, out pdbPath, out isPortableCodeView, out pdbChecksums);
+		}
+		
 		public byte[] GetMetadataBlob () {
 			if (metadata_blob != null)
 				return metadata_blob;

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
@@ -159,6 +159,11 @@ namespace Mono.Debugger.Soft
 				return meta = Mono.Cecil.AssemblyDefinition.ReadAssembly (ms);
 		}
 #endif
+		public bool HasDebugInfoLoaded()
+		{
+			return vm.conn.Assembly_HasDebugInfoLoaded (id);
+		}
+
 		public bool GetPdbInfo (out int age, out Guid guid, out string pdbPath, out bool isPortableCodeView, out PdbChecksum[] pdbChecksums)
 		{
 			return vm.conn.Assembly_GetDebugDirectoryInformation (id, out age, out guid, out pdbPath, out isPortableCodeView, out pdbChecksums);

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -569,7 +569,8 @@ namespace Mono.Debugger.Soft
 			GET_METHOD_FROM_TOKEN = 12,
 			HAS_DEBUG_INFO = 13,
 			GET_CATTRS = 14,
-			GET_DEBUG_INFORMATION = 17
+			GET_DEBUG_INFORMATION = 17,
+			HAS_DEBUG_INFO_LOADED = 18,
 		}
 
 		enum CmdModule {
@@ -2444,6 +2445,14 @@ namespace Mono.Debugger.Soft
 		internal bool Assembly_HasDebugInfo (long id) {
 			return SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.HAS_DEBUG_INFO, new PacketWriter ().WriteId (id)).ReadBool ();
 		}
+
+		internal bool Assembly_HasDebugInfoLoaded (long id)
+		{
+			if (!Version.AtLeast (2, 63))
+				return false;
+			return SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.HAS_DEBUG_INFO_LOADED, new PacketWriter ().WriteId (id)).ReadBool () ;
+		}
+
 		internal bool Assembly_GetDebugDirectoryInformation (long id, out int age, out Guid guid, out string pdbPath, out bool isPortableCodeView, out PdbChecksum[] pdbChecksums)
 		{
 			age = 0;

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -569,7 +569,7 @@ namespace Mono.Debugger.Soft
 			GET_METHOD_FROM_TOKEN = 12,
 			HAS_DEBUG_INFO = 13,
 			GET_CATTRS = 14,
-			GET_DEBUG_INFORMATION = 16
+			GET_DEBUG_INFORMATION = 17
 		}
 
 		enum CmdModule {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -2446,17 +2446,20 @@ namespace Mono.Debugger.Soft
 		}
 		internal bool Assembly_GetDebugDirectoryInformation (long id, out int age, out Guid guid, out string pdbPath, out bool isPortableCodeView, out PdbChecksum[] pdbChecksums)
 		{
-			List<PdbChecksum> pdbChecksumsList = new List<PdbChecksum> ();
+			age = 0;
+			guid = Guid.Empty;
+			pdbPath = "";
+			isPortableCodeView = false;
+			pdbChecksums = null;
+
+			if (!Version.AtLeast (2, 63))
+				return false;
+			
 			var packet = SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.GET_DEBUG_INFORMATION, new PacketWriter ().WriteId (id));
 			if (packet.ReadByte () == 0) //is embedded pdb or don't have debug info
-			{
-				age = 0;
-				guid = Guid.Empty;
-				pdbPath = "";
-				isPortableCodeView = false;
-				pdbChecksums = pdbChecksumsList.ToArray ();
 				return false;
-			}
+
+			List<PdbChecksum> pdbChecksumsList = new List<PdbChecksum> ();
 			age = packet.ReadInt ();
 			guid = new Guid(packet.ReadByteArray ());
 			pdbPath = packet.ReadString ();

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics;
+using Microsoft.FileFormats.PE;
 
 namespace Mono.Debugger.Soft
 {
@@ -515,6 +516,7 @@ namespace Mono.Debugger.Soft
 			INVOKE_METHODS = 13,
 			START_BUFFERING = 14,
 			STOP_BUFFERING = 15,
+			READ_MEMORY = 16,
 			GET_ENC_CAPABILITIES = 21
 		}
 
@@ -566,6 +568,8 @@ namespace Mono.Debugger.Soft
 			GET_TYPE_FROM_TOKEN = 11,
 			GET_METHOD_FROM_TOKEN = 12,
 			HAS_DEBUG_INFO = 13,
+			GET_CATTRS = 14,
+			GET_DEBUG_INFORMATION = 16
 		}
 
 		enum CmdModule {
@@ -2440,7 +2444,32 @@ namespace Mono.Debugger.Soft
 		internal bool Assembly_HasDebugInfo (long id) {
 			return SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.HAS_DEBUG_INFO, new PacketWriter ().WriteId (id)).ReadBool ();
 		}
-
+		internal bool Assembly_GetDebugDirectoryInformation (long id, out int age, out Guid guid, out string pdbPath, out bool isPortableCodeView, out PdbChecksum[] pdbChecksums)
+		{
+			List<PdbChecksum> pdbChecksumsList = new List<PdbChecksum> ();
+			var packet = SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.GET_DEBUG_INFORMATION, new PacketWriter ().WriteId (id));
+			if (packet.ReadByte () == 0) //is embedded pdb or don't have debug info
+			{
+				age = 0;
+				guid = Guid.Empty;
+				pdbPath = "";
+				isPortableCodeView = false;
+				pdbChecksums = pdbChecksumsList.ToArray ();
+				return false;
+			}
+			age = packet.ReadInt ();
+			guid = new Guid(packet.ReadByteArray ());
+			pdbPath = packet.ReadString ();
+			var lenPdbCheckSum = packet.ReadInt ();
+			for (int i = 0; i < lenPdbCheckSum; i++) {
+				var pdbHashType = packet.ReadString ();
+				var pdbChecksum = packet.ReadByteArray ();
+				pdbChecksumsList.Add (new PdbChecksum (pdbHashType, pdbChecksum));
+			}
+			isPortableCodeView = true;
+			pdbChecksums = pdbChecksumsList.ToArray ();
+			return true;
+		}
 		/*
 		 * TYPE
 		 */

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Location.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Location.cs
@@ -14,7 +14,7 @@ namespace Mono.Debugger.Soft
 		int end_line_number;
 		int end_column_number;
 		
-		internal Location (VirtualMachine vm, MethodMirror method, long native_addr, int il_offset, string source_file, int line_number, int column_number, int end_line_number, int end_column_number, byte[] hash) : base (vm, 0) {
+		public Location (VirtualMachine vm, MethodMirror method, long native_addr, int il_offset, string source_file, int line_number, int column_number, int end_line_number, int end_column_number, byte[] hash) : base (vm, 0) {
 			this.method = method;
 			//this.native_addr = native_addr;
 			this.il_offset = il_offset;

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -491,5 +491,23 @@ namespace Mono.Debugger.Soft
 		{
 			updatedByEnC = true;
 		}
+
+		public void SetDebugInfoFromPdb (int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files)
+		{
+			this.debug_info = new DebugInfo();
+			this.debug_info.max_il_offset = max_il_offset;
+			this.debug_info.il_offsets = il_offsets;
+			this.debug_info.line_numbers = line_numbers;
+			this.debug_info.column_numbers = column_numbers;
+			this.debug_info.end_line_numbers = end_line_numbers;
+			this.debug_info.end_column_numbers = end_column_numbers;
+			List<SourceInfo> sourceList = new List<SourceInfo>();
+			foreach (var source in source_files) {
+				var sourceInfo = new SourceInfo ();
+				sourceInfo.source_file = source;
+				sourceList.Add (sourceInfo);
+			}
+			this.debug_info.source_files = sourceList.ToArray();
+		}
 	}
 }

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/StackFrame.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/StackFrame.cs
@@ -248,5 +248,10 @@ namespace Mono.Debugger.Soft
 
 			return Method.GetLocals ().Where (l => l.LiveRangeStart <= location.ILOffset && l.LiveRangeEnd >= location.ILOffset && l.Name == name).FirstOrDefault ();
 		}
-    }
+
+		public void ClearDebugInfoToTryToGetFromLoadedPdb ()
+		{
+			location = null;
+		}
+	}
 }

--- a/Mono.Debugging.Soft/DebugSymbolsManager.cs
+++ b/Mono.Debugging.Soft/DebugSymbolsManager.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SymbolStore.SymbolStores;
+using Microsoft.SymbolStore;
+using Microsoft.FileFormats.PE;
+using Mono.Debugger.Soft;
+using Mono.Debugging.Client;
+using System.IO;
+using System.Threading;
+
+namespace Mono.Debugging.Soft
+{
+	internal enum SymbolStatus{
+		NotTriedToLoad,
+		NotFound,
+		LoadedFromSymbolServer,
+		NotLoadedFromSymbolServer
+	}
+	internal class DebugSymbolsInfo
+	{
+		internal SymbolStatus Status {
+			get; set;
+		}
+		
+		internal PortablePdbData PdbData {
+			get; set;
+		}
+		internal DebugSymbolsInfo(SymbolStatus status, PortablePdbData pdbData)
+		{
+			Status = status;
+			PdbData = pdbData;
+		}
+	}
+	public class DebugSymbolsManager
+	{
+		private readonly ITracer _tracer;
+		Dictionary<AssemblyMirror, DebugSymbolsInfo> symbolsByAssembly = new Dictionary<AssemblyMirror, DebugSymbolsInfo> ();
+		private string symbolCachePath;
+		private string[] symbolServerUrls;
+		private SymbolStore symbolStore;
+		private SoftDebuggerSession session;
+
+		internal DebugSymbolsManager (SoftDebuggerSession session)
+		{
+			this.session = session;
+			_tracer = new TracerSymbolServer (session.LogWriter);
+		}
+		public string HasSymbolLoaded (AssemblyMirror assembly)
+		{
+			if (session.SymbolPathMap.TryGetValue (assembly.Location, out string symbolPath))
+				return symbolPath;
+			if (symbolsByAssembly.TryGetValue (assembly, out var symbolsInfo))
+				return symbolsInfo.Status == SymbolStatus.NotLoadedFromSymbolServer ? "Dynamically loaded" : null;
+			return null;
+		}
+		public bool ForceLoadSymbolFromAssembly (AssemblyMirror assembly)
+		{
+			if (HasSymbolLoaded (assembly) != null)
+				return true;
+			return TryLoadSymbolFromSymbolServerIfNeeded (assembly).Result;
+		}
+
+		public void SetSymbolCache (string symbolCachePath)
+		{
+			this.symbolCachePath = symbolCachePath;
+			symbolStore = null;
+		}
+
+		public void SetSymbolServerUrl (string[] symbolServerUrls)
+		{
+			this.symbolServerUrls = symbolServerUrls;
+			symbolStore = null;
+			TryLoadSymbolFromSymbolServerIfNeeded ();
+		}
+
+		public void TryLoadSymbolFromSymbolServerIfNeeded ()
+		{
+			var assembliesToTryToLoadPPDB = symbolsByAssembly.Where (asm => asm.Value.Status == SymbolStatus.NotFound || asm.Value.Status == SymbolStatus.NotTriedToLoad).ToList ();
+			foreach (var asm in assembliesToTryToLoadPPDB) {
+				TryLoadSymbolFromSymbolServerIfNeeded (asm.Key);
+			}
+		}
+
+		internal PortablePdbData GetPdbData (AssemblyMirror asm, bool force = false)
+		{
+			string pdbFileName;
+			PortablePdbData portablePdb = null;
+			if (symbolsByAssembly.TryGetValue (asm, out var symbolsInfo) && (symbolsInfo.PdbData != null || (!force && symbolsInfo.Status == SymbolStatus.NotFound))) {
+				return symbolsInfo.PdbData;
+			}
+
+			if (!session.SymbolPathMap.TryGetValue (asm.GetName ().FullName, out pdbFileName) || Path.GetExtension (pdbFileName) != ".pdb") {
+				string assemblyFileName;
+				if (!session.AssemblyPathMap.TryGetValue (asm.GetName ().FullName, out assemblyFileName))
+					assemblyFileName = asm.Location;
+				pdbFileName = Path.ChangeExtension (assemblyFileName, ".pdb");
+			}
+			if (PortablePdbData.IsPortablePdb (pdbFileName)) {
+				portablePdb = new PortablePdbData (pdbFileName);
+			} else {
+				// Attempt to fetch pdb from the debuggee over the wire
+				var pdbBlob = asm.GetPdbBlob ();
+				portablePdb = pdbBlob != null ? new PortablePdbData (pdbBlob) : null;
+			}
+			if (portablePdb == null)
+				symbolsByAssembly[asm] = new DebugSymbolsInfo (SymbolStatus.NotFound, null);
+			else
+				symbolsByAssembly[asm] = new DebugSymbolsInfo (SymbolStatus.NotLoadedFromSymbolServer, portablePdb);
+			return portablePdb;
+		}
+
+		internal Location FindLocationsByFileInPdbLoadedFromSymbolServer (string fileName, int line, int column)
+		{
+			foreach (var symbolServerPPDB in symbolsByAssembly.Where(item => item.Value.Status == SymbolStatus.LoadedFromSymbolServer)) {
+				var location = symbolServerPPDB.Value.PdbData.GetLocationByFileName (symbolServerPPDB.Key, fileName, line, column);
+				if (location != null)
+					return location;
+			}
+			return null;
+		}
+
+		internal void CreateSymbolStore ()
+		{
+			foreach (var urlServer in symbolServerUrls) {
+				if (string.IsNullOrEmpty (urlServer))
+					continue;
+				try {
+					symbolStore = new HttpSymbolStore (_tracer, symbolStore, new Uri ($"{urlServer}/"), null);
+				} catch (Exception ex) {
+					_tracer.Warning ($"Failed to create HttpSymbolStore for this URL - {urlServer} - {ex.Message}");
+				}
+			}
+			if (!string.IsNullOrEmpty (symbolCachePath)) {
+				try {
+					symbolStore = new CacheSymbolStore (_tracer, symbolStore, symbolCachePath);
+				} catch (Exception ex) {
+					_tracer.Warning ( $"Failed to create CacheSymbolStore for this path - {symbolCachePath} - {ex.Message}");
+				}
+			}
+		}
+
+		public async Task<bool> TryLoadSymbolFromSymbolServerIfNeeded (AssemblyMirror asm)
+		{
+			var asmName = asm.GetName ().FullName;
+			if (asm.HasDebugInfoLoaded ())
+				return true;
+			if (session.SymbolPathMap.ContainsKey (asmName))
+				return true;
+			if (symbolsByAssembly.TryGetValue (asm, out var symbolsInfo)) {
+				if (symbolsInfo.Status == SymbolStatus.NotFound)
+					return false;
+				if (symbolsInfo.Status != SymbolStatus.NotTriedToLoad)
+					return true;
+			}
+			if (session.JustMyCode) {
+				symbolsByAssembly[asm] = new DebugSymbolsInfo (SymbolStatus.NotTriedToLoad, null);
+				return false;
+			}
+			if (symbolStore == null)
+				CreateSymbolStore ();
+			if (symbolStore == null)
+				return false;
+			if (asm.GetPdbInfo (out int age, out Guid guid, out string pdbPath, out bool isPortableCodeView, out PdbChecksum[] pdbChecksums) == false)
+				return false;
+			var pdbName = Path.GetFileName (pdbPath);
+			var pdbGuid = guid.ToString ("N").ToUpperInvariant () + (isPortableCodeView ? "FFFFFFFF" : age.ToString ());
+			var key = $"{pdbName}/{pdbGuid}/{pdbName}";
+			SymbolStoreFile file = await symbolStore.GetFile (new SymbolStoreKey (key, pdbPath, false, pdbChecksums), new CancellationTokenSource ().Token).ConfigureAwait (false);
+			if (file != null) {
+				session.SymbolPathMap[asmName] = Path.Combine (symbolCachePath, key);
+				var portablePdb = GetPdbData (asm, true);
+				if (portablePdb != null) {
+					symbolsByAssembly[asm] = new DebugSymbolsInfo(SymbolStatus.LoadedFromSymbolServer, portablePdb);
+					session.TryResolvePendingBreakpoints ();
+				} else {
+					symbolsByAssembly[asm] = new DebugSymbolsInfo (SymbolStatus.NotFound, null);
+					return false;
+				}
+			}
+			else {
+				symbolsByAssembly[asm] = new DebugSymbolsInfo (SymbolStatus.NotFound, null);
+				return false;
+			}
+			return true;
+		}
+	}
+	public sealed class TracerSymbolServer : ITracer
+	{
+		private readonly OutputWriterDelegate writer;
+
+		public TracerSymbolServer (OutputWriterDelegate writer)
+		{
+			this.writer = writer;
+		}
+
+		public void WriteLine (string message) => writer?.Invoke (false, message);
+
+		public void WriteLine (string format, params object[] arguments) => writer?.Invoke (false, string.Format (format, arguments));
+
+		public void Information (string message) => writer?.Invoke (false, message);
+
+		public void Information (string format, params object[] arguments) => writer?.Invoke (false, string.Format (format, arguments));
+
+		public void Warning (string message) => writer?.Invoke (false, message);
+		public void Warning (string format, params object[] arguments) => writer?.Invoke (false, string.Format (format, arguments));
+
+		public void Error (string message) => writer?.Invoke (false, message);
+
+		public void Error (string format, params object[] arguments) => writer?.Invoke (false, string.Format (format, arguments));
+
+		public void Verbose (string message) => writer?.Invoke (false, message);
+
+		public void Verbose (string format, params object[] arguments) => writer?.Invoke (false, string.Format (format, arguments));
+	}
+}

--- a/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
@@ -151,7 +151,7 @@ namespace Mono.Debugging.Soft
 
 			if (fileName ==  null) {
 
-				var ppdb = session.GetPdbData (frame.Method.DeclaringType.Assembly);
+				var ppdb = session.GetPdbData (frame.Method);
 				if (ppdb != null) {
 					(int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files) = ppdb.GetDebugInfoFromPdb (method);
 					frame.Method.SetDebugInfoFromPdb (max_il_offset, il_offsets, line_numbers, column_numbers, end_line_numbers, end_column_numbers, source_files);

--- a/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
@@ -75,6 +75,7 @@ namespace Mono.Debugging.Soft
 						}
 					}
 					catch (Exception) {
+						DC.DebuggerLoggingService.LogMessage ($"File with uri={location.SourceLink.Uri} is not available for download");
 						//expected exception when file is not available for download
 					}
 				}

--- a/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
@@ -150,14 +150,18 @@ namespace Mono.Debugging.Soft
 			int endColumnNumber = frame.Location.EndColumnNumber;
 
 			if (fileName ==  null) {
-				(int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files) = session.GetPdbData (frame.Method.DeclaringType.Assembly).GetDebugInfoFromPdb (method);
-				frame.Method.SetDebugInfoFromPdb (max_il_offset, il_offsets, line_numbers, column_numbers, end_line_numbers, end_column_numbers, source_files);
-				frame.ClearDebugInfoToTryToGetFromLoadedPdb ();
-				fileName = frame.FileName;
-				lineNumber = frame.LineNumber;
-				columnNumber = frame.ColumnNumber;
-				endLineNumber = frame.Location.EndLineNumber;
-				endColumnNumber = frame.Location.EndColumnNumber;
+
+				var ppdb = session.GetPdbData (frame.Method.DeclaringType.Assembly);
+				if (ppdb != null) {
+					(int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files) = ppdb.GetDebugInfoFromPdb (method);
+					frame.Method.SetDebugInfoFromPdb (max_il_offset, il_offsets, line_numbers, column_numbers, end_line_numbers, end_column_numbers, source_files);
+					frame.ClearDebugInfoToTryToGetFromLoadedPdb ();
+					fileName = frame.FileName;
+					lineNumber = frame.LineNumber;
+					columnNumber = frame.ColumnNumber;
+					endLineNumber = frame.Location.EndLineNumber;
+					endColumnNumber = frame.Location.EndColumnNumber;
+				}
 			}
 			
 			

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -117,13 +117,16 @@ namespace Mono.Debugging.Soft
 
 		public bool JustMyCode {
 			get { return justMyCode && Options.ProjectAssembliesOnly; }
-			set {
-				var oldValue = justMyCode;
-				justMyCode = value;
-				if (oldValue == true && oldValue != value) {
-					DebugSymbolsManager.TryLoadSymbolFromSymbolServerIfNeeded ();
-				}
+		}
+
+		public async Task<bool> SetJustMyCode(bool value)
+		{
+			var oldValue = justMyCode;
+			justMyCode = value;
+			if (oldValue == true && oldValue != value) {
+				await DebugSymbolsManager.TryLoadSymbolFromSymbolServerIfNeeded ();
 			}
+			return true;
 		}
 
 		public SoftDebuggerSession ()

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -56,7 +56,6 @@ namespace Mono.Debugging.Client
 		readonly object breakpointStoreLock = new object ();
 		BreakpointStore breakpointStore;
 		DebuggerSessionOptions options;
-		bool justMyCode;
 		ProcessInfo[] currentProcesses;
 		ThreadInfo activeThread;
 		bool ownedBreakpointStore;
@@ -856,11 +855,6 @@ namespace Mono.Debugging.Client
 		/// </summary>
 		public DebuggerSessionOptions Options {
 			get { return options; }
-		}
-		
-		public bool JustMyCode {
-			get { return justMyCode && Options.ProjectAssembliesOnly; }
-			set { justMyCode = value; }
 		}
 		
 		/// <summary>

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs
@@ -56,6 +56,7 @@ namespace Mono.Debugging.Client
 		readonly object breakpointStoreLock = new object ();
 		BreakpointStore breakpointStore;
 		DebuggerSessionOptions options;
+		bool justMyCode;
 		ProcessInfo[] currentProcesses;
 		ThreadInfo activeThread;
 		bool ownedBreakpointStore;
@@ -855,6 +856,11 @@ namespace Mono.Debugging.Client
 		/// </summary>
 		public DebuggerSessionOptions Options {
 			get { return options; }
+		}
+		
+		public bool JustMyCode {
+			get { return justMyCode && Options.ProjectAssembliesOnly; }
+			set { justMyCode = value; }
 		}
 		
 		/// <summary>

--- a/Mono.Debugging/Mono.Debugging.Client/DebuggerSessionOptions.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/DebuggerSessionOptions.cs
@@ -46,9 +46,6 @@ namespace Mono.Debugging.Client
 		public bool ProjectAssembliesOnly { get; set; }
 		public AutomaticSourceDownload AutomaticSourceLinkDownload { get; set; }
 		public bool DebugSubprocesses { get; set; }
-		public ImmutableArray<SymbolSource> SymbolSearchPaths { get; set; } = ImmutableArray<SymbolSource>.Empty;
-		public bool SearchMicrosoftSymbolServer { get; set; }
-		public bool SearchNuGetSymbolServer { get; set; }
 	}
 
 	[Serializable]


### PR DESCRIPTION
I need these informations to correct create the URL to download symbols from symbol server.

I created a new message to avoid passing all the assembly content over the protocol and read it using PEReader which would be easier, but it would spend more time and more memory on client side also.

Related to PRs on runtime and debugger-vs repo:
https://github.com/dotnet/runtime/pull/82555
https://github.com/xamarin/debugger-vs/pull/315

https://user-images.githubusercontent.com/4503299/221028994-a9e5c64b-ae8f-4c85-865e-8d3631d775db.mp4