### PR TITLE
[Backport Release-17.6-vsmac] Don't let there be a null name in the ProcessInfo constructor

### DIFF
--- a/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
@@ -64,14 +64,14 @@ namespace Mono.Debugging.Client
 
 		public ProcessInfo (string name, string description)
 		{
-			this.name = name;
-			this.description = description;
+			this.name = name ?? string.Empty;
+			this.description = description ?? string.Empty;
 		}
 
 		public ProcessInfo (long id, string name)
 		{
 			this.id = id;
-			this.name = name;
+			this.name = name ?? string.Empty;
 		}
 		
 		public ThreadInfo[] GetThreads ()

--- a/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
+++ b/Mono.Debugging/Mono.Debugging.Client/ProcessInfo.cs
@@ -65,7 +65,7 @@ namespace Mono.Debugging.Client
 		public ProcessInfo (string name, string description)
 		{
 			this.name = name ?? string.Empty;
-			this.description = description ?? string.Empty;
+			this.description = description;
 		}
 
 		public ProcessInfo (long id, string name)


### PR DESCRIPTION
Backport of https://github.com/mono/debugger-libs/pull/386