### PR TITLE
This will add the non-default nuget key to avoid compilation error.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,5 +1,6 @@
 <configuration>
     <config>
         <add key="repositoryPath" value="packages" />
+        <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json">
     </config>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,6 @@
 <configuration>
     <config>
         <add key="repositoryPath" value="packages" />
-        <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json">
+        <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     </config>
 </configuration>


### PR DESCRIPTION
Fixes https://github.com/mono/debugger-libs/issues/389