### PR TITLE
Allow checking only runtime version when invoking VersionInfo.AtLeast

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -33,19 +33,24 @@ namespace Mono.Debugger.Soft
 		/*
 		 * Check that this version is at least major:minor
 		 */
-		public bool AtLeast (int major, int minor) {
-			if (debuggerLibsMajorVersion > 2 || (debuggerLibsMajorVersion == 2 && debuggerLibsMinorVersion >= 56))
+		public bool AtLeast (int major, int minor, bool checkOnlyRuntime = false) {
+			if (checkOnlyRuntime)
+				return AtLeastRuntime (major, minor);
+
+			if (AtLeastDebuggerLibs(2, 56))
 			{
-				if (((MajorVersion > major) || ((MajorVersion == major && MinorVersion >= minor))) &&
-					((debuggerLibsMajorVersion > major) || ((debuggerLibsMajorVersion == major && debuggerLibsMinorVersion >= minor))))
+				if (AtLeastRuntime (major, minor) && AtLeastDebuggerLibs(major, minor))
 					return true;
+
 				return false;
 			}
-			if ((MajorVersion > major) || ((MajorVersion == major && MinorVersion >= minor)))
-				return true;
-			else
-				return false;
+
+			return AtLeastRuntime (major, minor);
 		}
+
+		bool AtLeastRuntime (int major, int minor) => MajorVersion > major || (MajorVersion == major && MinorVersion >= minor);
+
+		bool AtLeastDebuggerLibs (int major, int minor) => debuggerLibsMajorVersion > major || (debuggerLibsMajorVersion == major && debuggerLibsMinorVersion >= minor);
 	}
 
 	struct SourceInfo {

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/ModuleMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/ModuleMirror.cs
@@ -77,7 +77,7 @@ namespace Mono.Debugger.Soft
 		// Since protocol version 2.60
 		public void ApplyChanges (ArrayMirror dmeta, ArrayMirror dIL, Value dPDB) {
 		    /* dPDB is Value because it can be ArrayMirror or PrimitiveValue (vm, null) */
-		    vm.CheckProtocolVersion (2, 60);
+		    vm.CheckProtocolVersion (2, 60, checkOnlyRuntime: true);
 		    vm.conn.Module_ApplyChanges (id, dmeta.Id, dIL.Id, dPDB.Id);
 		}
 	}

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -791,14 +791,14 @@ namespace Mono.Debugger.Soft
 			return res;
 		}
 
-		internal void CheckProtocolVersion (int major, int minor) {
-			if (!conn.Version.AtLeast (major, minor))
+		internal void CheckProtocolVersion (int major, int minor, bool checkOnlyRuntime = false) {
+			if (!conn.Version.AtLeast (major, minor, checkOnlyRuntime))
 				throw new NotSupportedException ("This request is not supported by the protocol version implemented by the debuggee.");
 		}
 
 		public string GetEnCCapabilities ()
 		{
-			if (conn.Version.AtLeast (2, 61))
+			if (conn.Version.AtLeast (2, 61, checkOnlyRuntime: true))
 				return conn.VM_EnCCapabilities ();
 			return "Baseline";
 		}


### PR DESCRIPTION
Also, ensure we only check runtime version on EnC related checks

This should fix a bug where C# Hot Reload was not working correctly on net7