### PR TITLE
Fix add breakpoint and viewing locals from a pdb loaded on debugger side.

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -2311,7 +2311,7 @@ namespace Mono.Debugger.Soft
 				info.live_range_start [i] = res.ReadInt ();
 				info.live_range_end [i] = res.ReadInt ();
 			}
-			if (Version.AtLeast (2, 65) && res.HasMoreData()) {
+			if (Version.AtLeast (2, 65) && (nlocals == 0 || res.HasMoreData())) {
 				info.indexes = new int [nlocals];
 				for (int i = 0; i < nlocals; ++i) {
 					info.indexes [i] = res.ReadInt ();

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -65,6 +65,8 @@ namespace Mono.Debugger.Soft
 		public int[] column_numbers;
 		public int[] end_line_numbers;
 		public int[] end_column_numbers;
+		public int[] local_indexes_loaded_from_pdb;
+		public string[] local_names_loaded_from_pdb;
 		public SourceInfo[] source_files;
 	}
 
@@ -861,6 +863,13 @@ namespace Mono.Debugger.Soft
 
 			public int ReadShort () {
 				return decode_short (packet, ref offset);
+			}
+
+			public bool HasMoreData ()
+			{
+				if (packet.Length > offset)
+					return true;
+				return false;
 			}
 
 			public int ReadInt () {
@@ -2302,7 +2311,7 @@ namespace Mono.Debugger.Soft
 				info.live_range_start [i] = res.ReadInt ();
 				info.live_range_end [i] = res.ReadInt ();
 			}
-			if (Version.AtLeast (2, 65)) {
+			if (Version.AtLeast (2, 65) && res.HasMoreData()) {
 				info.indexes = new int [nlocals];
 				for (int i = 0; i < nlocals; ++i) {
 					info.indexes [i] = res.ReadInt ();

--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -288,8 +288,12 @@ namespace Mono.Debugger.Soft
 
 				for (int i = 0; i < li.names.Length; ++i)
 				{
-					if (vm.Version.AtLeast (2, 65))
-						locals [i + pi.Length] = new LocalVariable (vm, this, li.indexes [i], li.types [i], li.names [i], li.live_range_start [i], li.live_range_end [i], false);
+					if (vm.Version.AtLeast (2, 65)) {
+						if (li.indexes != null)
+							locals[i + pi.Length] = new LocalVariable (vm, this, li.indexes[i], li.types[i], li.names[i], li.live_range_start[i], li.live_range_end[i], false);
+						else
+							locals[i + pi.Length] = new LocalVariable (vm, this, debug_info.local_indexes_loaded_from_pdb[i], li.types[i], debug_info.local_names_loaded_from_pdb[i], li.live_range_start[i], li.live_range_end[i], false);
+					}
 					else
 						locals [i + pi.Length] = new LocalVariable (vm, this, i, li.types [i], li.names [i], li.live_range_start [i], li.live_range_end [i], false);
 				}
@@ -497,7 +501,7 @@ namespace Mono.Debugger.Soft
 			updatedByEnC = true;
 		}
 
-		public void SetDebugInfoFromPdb (int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files)
+		public void SetDebugInfoFromPdb (int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files, int[] local_indexes_loaded_from_pdb, string[] local_names_loaded_from_pdb)
 		{
 			this.debug_info = new DebugInfo();
 			this.debug_info.max_il_offset = max_il_offset;
@@ -506,6 +510,8 @@ namespace Mono.Debugger.Soft
 			this.debug_info.column_numbers = column_numbers;
 			this.debug_info.end_line_numbers = end_line_numbers;
 			this.debug_info.end_column_numbers = end_column_numbers;
+			this.debug_info.local_indexes_loaded_from_pdb = local_indexes_loaded_from_pdb;
+			this.debug_info.local_names_loaded_from_pdb = local_names_loaded_from_pdb;
 			List<SourceInfo> sourceList = new List<SourceInfo>();
 			foreach (var source in source_files) {
 				var sourceInfo = new SourceInfo ();

--- a/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerBacktrace.cs
@@ -156,13 +156,13 @@ namespace Mono.Debugging.Soft
 			int endLineNumber = frame.Location.EndLineNumber;
 			int endColumnNumber = frame.Location.EndColumnNumber;
 
-			if (fileName ==  null && !session.JustMyCode) {
+			if (fileName == null) {
 				try {
 					var ppdb = session.GetPdbData (frame.Method);
 					if (ppdb != null) {
-						(int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files) = ppdb.GetDebugInfoFromPdb (method);
+						(int max_il_offset, int[] il_offsets, int[] line_numbers, int[] column_numbers, int[] end_line_numbers, int[] end_column_numbers, string[] source_files, int[] local_indexes, string[] local_names) = ppdb.GetDebugInfoFromPdb (method);
 						if (source_files.Length > 0) {
-							frame.Method.SetDebugInfoFromPdb (max_il_offset, il_offsets, line_numbers, column_numbers, end_line_numbers, end_column_numbers, source_files);
+							frame.Method.SetDebugInfoFromPdb (max_il_offset, il_offsets, line_numbers, column_numbers, end_line_numbers, end_column_numbers, source_files, local_indexes, local_names);
 							frame.ClearDebugInfoToTryToGetFromLoadedPdb ();
 							fileName = frame.FileName;
 							lineNumber = frame.LineNumber;

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1251,7 +1251,7 @@ namespace Mono.Debugging.Soft
 			}
 
 			if (!found) {
-				var location = DebugSymbolsManager.FindLocationsByFileInPdbLoadedFromSymbolServer (breakpoint.FileName, breakpoint.Line, breakpoint.Column);
+				var location = DebugSymbolsManager.FindLocationsByFileInPdbLoadedOnDebuggerSide (breakpoint.FileName, breakpoint.Line, breakpoint.Column);
 				if (location != null) {
 					breakInfo.Location = location;
 					InsertBreakpoint (breakpoint, breakInfo);


### PR DESCRIPTION
Setting breakpoint in a dll with symbols not loaded by runtime. View locals from a dll with symbols not loaded by runtime.

Fix https://github.com/dotnet/runtime/issues/104265