### PR TITLE
Retrieve only necessary assembly info for debug session

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -2286,17 +2286,8 @@ namespace Mono.Debugging.Soft
 		private void HandleAssemblyLoaded (AssemblyMirror asm)
 		{
 			var name = asm.GetName ();
-			var assemblyObject = asm.GetAssemblyObject ();
-			bool isDynamic = asm.IsDynamic;
-			string assemblyName;
-			bool hasSymbol;
-			if (!isDynamic) {
-				assemblyName = name.Name;
-				hasSymbol = asm.HasDebugInfo;
-			} else {
-				assemblyName = string.Empty;
-				hasSymbol = false;
-			}
+			var assemblyName = name.Name;
+			var hasSymbol = false;
 			var assembly = new Assembly (
 					assemblyName,
 					asm?.Location ?? string.Empty,
@@ -2308,12 +2299,12 @@ namespace Mono.Debugging.Soft
 					name?.Version?.Major.ToString () ?? string.Empty,
 					// TODO: module time stamp
 					string.Empty,
-					assemblyObject?.Address.ToString () ?? string.Empty,
+					string.Empty,
 					string.Format ("[{0}]{1}", asm?.VirtualMachine?.TargetProcess?.Id ?? -1, asm?.VirtualMachine?.TargetProcess?.ProcessName ?? string.Empty),
 					asm?.Domain?.FriendlyName ?? string.Empty,
 					asm?.VirtualMachine?.TargetProcess?.Id ?? -1,
 					hasSymbol,
-					isDynamic
+					false
 			);
 
 			OnAssemblyLoaded (assembly);


### PR DESCRIPTION
As we are reading all the assembly information from protocol, scenarios where the debugger goes over the network are heavily impacted by the amount of information we get.

By not retrieving information that's not necessary we are improving the assembly load times, which improves the app launch times. This is specially important for remote iOS scenarios from Visual Studio.