### PR TITLE
Fix `NU1510` warning as error

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
@@ -26,8 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionCecil)" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Reflection.Metadata" Version="5.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.1" Condition=" '$(TargetFramework)' == 'net472' " />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0" Condition=" '$(TargetFramework)' == 'net472' " />
     <PackageReference Include="Microsoft.SymbolStore" Version="1.0.411401" />
     <PackageReference Include="Microsoft.FileFormats" Version="1.0.411401" />
   </ItemGroup>

--- a/Mono.Debugging/Mono.Debugging.csproj
+++ b/Mono.Debugging/Mono.Debugging.csproj
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(NuGetVersionSystemCollectionsImmutable)" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" Condition=" '$(TargetFramework)' == 'net472' " />
+    <PackageReference Include="System.Collections.Immutable" Version="$(NuGetVersionSystemCollectionsImmutable)" Condition=" '$(TargetFramework)' == 'net472' " />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(NuGetVersionRoslyn)" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://github.com/NuGet/NuGet.Client/pull/6239

.NET 10 Preview 1 enables `$(RestoreEnablePackagePruning)=true` by default.

This produces multiple warnings (as errors) in dotnet/android:

    external/debugger-libs/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj : warning NU1510: PackageReference System.Runtime will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    external/debugger-libs/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj : warning NU1510: PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    external/debugger-libs/Mono.Debugging/Mono.Debugging.csproj : warning NU1510: PackageReference System.Buffers will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    external/debugger-libs/Mono.Debugging/Mono.Debugging.csproj : warning NU1510: PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.

It appears we can safely remove these references for `net6.0` `$(TargetFramework)`, and only have them for `net472`.

I tested these changes here:

* https://github.com/dotnet/android/pull/9771