### PR TITLE
[perf] Fixed PerfWatson in Mono.Debugger.Soft.Connection.disconnected_check

### DIFF
--- a/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -1540,7 +1540,7 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
-		bool disconnected;
+		volatile bool disconnected;
 		VMCrashException crashed;
 
 		internal ManualResetEvent DisconnectedEvent = new ManualResetEvent (false);
@@ -1575,14 +1575,12 @@ namespace Mono.Debugger.Soft
 		}
 
 		void disconnected_check () {
-			lock (reply_packets_monitor) {
-				if (!disconnected)
-					return;
-				else if (crashed != null)
-					throw crashed;
-				else
-					throw new VMDisconnectedException ();
-			}
+			if (!disconnected)
+				return;
+			else if (crashed != null)
+				throw crashed;
+			else
+				throw new VMDisconnectedException ();
 		}
 
 		bool ReceivePacket () {


### PR DESCRIPTION
With another recent PerfWatson fix (https://github.com/mono/debugger-libs/commit/824fc626b9e0f95936e6683e5553ecbba47a38c6), a lock has been introduced in the disconnected_check method, to mostly control the access of the disconnected property. This caused a new PerfWatson issue, so this change reverts that extra threading control and instead converts the disconnected boolean variable into a volatile variable, so the latest updated value is always guaranteed for multi threading access, without the need of an unnecessary and blocking lock.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2481686/?view=edit