### PR TITLE
Fix NuGet config to support network-isolated CI

### DIFF
--- a/Mono.Debugging.Soft/nuget.config
+++ b/Mono.Debugging.Soft/nuget.config
@@ -1,7 +1,0 @@
-<configuration>
-    <packageSources>
-        <clear />
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-        <add key="dnceng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    </packageSources>
-</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,8 @@
 <configuration>
     <config>
         <add key="repositoryPath" value="packages" />
-        <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     </config>
+    <packageSources>
+        <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    </packageSources>
 </configuration>


### PR DESCRIPTION
Remove Mono.Debugging.Soft/nuget.config which had <clear /> and an explicit nuget.org source that breaks builds under network isolation.

Fix root NuGet.config by moving the dnceng (dotnet-tools) feed from the <config> section (where NuGet ignored it as a package source) to a proper <packageSources> section.

OSS contributors still get nuget.org from the .NET SDK machine-level default, and CI environments can override sources via parent configs.